### PR TITLE
Add Github CI action

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,12 @@
+[profile.ci]
+# Retry tests before failing them.
+retries = { backoff = "exponential", count = 2, delay = "2s" }
+# Do not cancel the test run on the first failure.
+fail-fast = false
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+
+# save junit report
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -1,0 +1,25 @@
+---
+title: Flaky test `{{ env.TEST_NAME }}`
+---
+
+## Last report
+
+### System error
+
+```text
+{{ env.SYSTEM_ERROR }}
+```
+
+### Context
+
+Date: {{ date | date('DD.MM.YYYY HH:mm') }}
+
+[Flaky failure run](https://github.com/{{ env.REPOSITORY }}/actions/runs/{{ env.RUN_ID }}/job/{{ env.JOB_ID }})
+
+[Commit](https://github.com/{{ env.REPOSITORY }}/tree/{{ env.SHA }})
+
+OS: {{ env.OS }}
+
+Branch: {{ env.BRANCH }}
+
+{{ env.PR }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,106 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
+    branches: [ '**' ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4  
+
+    - name: Cache rust cargo artifacts
+      uses: Swatinem/rust-cache@v2
+
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+
+    - name: Build
+      run: cargo build --tests --workspace
+
+    - name: Run tests
+      # Profile "ci" is configured in .config/nextest.toml
+      run: cargo nextest run --workspace --profile ci
+      
+    # nextest doesn't run doctests https://github.com/nextest-rs/nextest/issues/16
+    - name: Run doc tests
+      run: cargo test --doc
+
+    - name: Upload test report
+      uses: actions/upload-artifact@v4
+      with:
+        name: junit-${{ matrix.os }}.xml
+        path: target/nextest/ci/junit.xml
+
+  # After tests are run, this hacky script will process the JUnit output of nextest
+  # and will create a GH Issue if there is a test marked as flaky,
+  # Failure of updating an issue is ignored because it fails for external contributors.
+  process-results:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest  ]
+    steps:
+      - name: Download test report
+        uses: actions/download-artifact@v4
+        with:
+          name: junit-${{ matrix.os }}.xml
+      - name: Process test report
+        id: process-test-report
+        run: |
+          pip install yq
+          xq '.. | select(type == "object") | select(has("flakyFailure"))' junit.xml > flaky_tests.json
+          echo has_flaky_tests=$(jq '. | has("flakyFailure")' flaky_tests.json) >> $GITHUB_OUTPUT
+      - name: Get flaky test details
+        id: get-flaky-tests
+        if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
+        run: |
+          echo "Flaky tests found"
+          echo test=$(jq '.["@name"]' flaky_tests.json -r ) >> $GITHUB_OUTPUT
+          delimiter="###r###"
+          echo "content<<$delimiter" >> $GITHUB_OUTPUT
+          echo "$(jq '[.flakyFailure] | flatten | .[0]["system-err"]' flaky_tests.json -r)" >> $GITHUB_OUTPUT
+          echo $delimiter >> $GITHUB_OUTPUT
+      - name: pull issue template
+        if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/ISSUE_TEMPLATE/flaky_test.md
+          sparse-checkout-cone-mode: false
+      - name: Create issue for flaky tests
+        continue-on-error: true
+        id: create-issue
+        if: ${{ steps.process-test-report.outputs.has_flaky_tests == 'true' }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_NAME: ${{ steps.get-flaky-tests.outputs.test }}
+          SYSTEM_ERROR: ${{ steps.get-flaky-tests.outputs.content }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          JOB_ID: ${{ github.job }}
+          SHA: ${{ github.sha }}
+          WORKFLOW: ${{ github.workflow }}
+          JOB: ${{ github.job }}
+          BRANCH: ${{ github.ref }}
+          OS: ${{ matrix.os }}
+          PR: "#${{ github.event.pull_request.number }}"
+        with:
+          filename: .github/ISSUE_TEMPLATE/flaky_test.md
+          update_existing: true


### PR DESCRIPTION
This pull request introduces a new CI configuration, a template for reporting flaky tests, and updates to the CI workflow to handle test retries and flaky test reporting.

### CI Configuration:

* Added a new CI profile in `.config/nextest.toml` to handle test retries, configure failure output, and save JUnit reports.

### Flaky Test Reporting:

* Created a new issue template `.github/ISSUE_TEMPLATE/flaky_test.md` for reporting flaky tests with details such as system error, context, and links to the relevant GitHub actions run and commit.

### CI Workflow:

* Updated the CI workflow in `.github/workflows/ci.yaml` to include steps for building, testing, caching artifacts, and uploading test reports. The workflow now also processes test reports to identify flaky tests and create GitHub issues for them.