### PR TITLE
Add validate command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,9 @@
     "editor.defaultFormatter": null,
     "[rust]": {
       "editor.defaultFormatter": "rust-lang.rust-analyzer",
-      "editor.formatOnSave": true
+      "editor.formatOnSave": true,
+      "rust-analyzer.cargo.targetDir": true,
+      "rust-analyzer.checkOnSave.extraArgs":["--target-dir","/tmp/rust-analyzer-check"]
     },
     "cSpell.words": [
       "Alireza",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,10 +27,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
+name = "bytes"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cfg-if"
@@ -36,7 +128,56 @@ name = "chico_server"
 version = "0.1.0"
 dependencies = [
  "chico_file",
+ "clap",
+ "rstest",
+ "tokio",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "equivalent"
@@ -88,6 +229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +260,28 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "libc"
+version = "0.2.170"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
 ]
 
 [[package]]
@@ -122,6 +297,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +324,44 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
 ]
 
 [[package]]
@@ -168,6 +401,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -236,6 +478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,10 +493,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -260,6 +523,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+
+[[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +553,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -292,6 +606,100 @@ name = "unicode-ident"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,7 @@ dependencies = [
  "assert_cmd",
  "chico_file",
  "clap",
+ "predicates",
  "rstest",
  "tempfile",
  "tokio",
@@ -241,6 +242,15 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "futures-core"
@@ -402,6 +412,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,7 +484,10 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +120,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
+name = "bstr"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,9 +154,11 @@ dependencies = [
 name = "chico_server"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "chico_file",
  "clap",
  "rstest",
+ "tempfile",
  "tokio",
 ]
 
@@ -180,10 +209,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "futures-core"
@@ -226,6 +283,18 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -275,6 +344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,7 +387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -375,6 +450,33 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -493,6 +595,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +618,26 @@ name = "semver"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+
+[[package]]
+name = "serde"
+version = "1.0.218"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.218"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -554,6 +689,26 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tempfile"
+version = "3.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tokio"
@@ -614,10 +769,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "windows-sys"
@@ -708,4 +881,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
 ]

--- a/chico_file/src/lib.rs
+++ b/chico_file/src/lib.rs
@@ -11,7 +11,7 @@ use nom::{
     Err, IResult,
 };
 
-mod types;
+pub mod types;
 
 // Parses a single-line comment like "# this is a comment"
 fn parse_comment(input: &str) -> IResult<&str, ()> {

--- a/chico_server/Cargo.toml
+++ b/chico_server/Cargo.toml
@@ -9,6 +9,11 @@ documentation.workspace = true
 
 [dependencies]
 chico_file = { path = "../chico_file" }
+clap = { version = "4.5", features = ["derive"] }
+tokio = { version = "1" , features = ["full"]}
+
+[dev-dependencies]
+rstest = "0.24.0"
 
 [lints]
 workspace = true

--- a/chico_server/Cargo.toml
+++ b/chico_server/Cargo.toml
@@ -16,6 +16,8 @@ tokio = { version = "1" , features = ["full"]}
 rstest = "0.24.0"
 assert_cmd = "2.0"
 tempfile = "3"
+predicates = "3.1.3"
+
 
 [lints]
 workspace = true
@@ -24,3 +26,7 @@ workspace = true
 # Treat warnings as a build error.
 strict = []
 default = ["strict"] 
+
+[[bin]]
+name = "chico"
+path = "src/main.rs"

--- a/chico_server/Cargo.toml
+++ b/chico_server/Cargo.toml
@@ -14,6 +14,8 @@ tokio = { version = "1" , features = ["full"]}
 
 [dev-dependencies]
 rstest = "0.24.0"
+assert_cmd = "2.0"
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/chico_server/src/cli.rs
+++ b/chico_server/src/cli.rs
@@ -34,7 +34,7 @@ mod tests {
 
         match cli.command {
             Commands::Validate { config } => assert_eq!(config, "/path/to/file"),
-            _ => panic!("Expected 'New' command"),
+            _ => panic!("Expected 'Validate' command"),
         }
     }
 }

--- a/chico_server/src/cli.rs
+++ b/chico_server/src/cli.rs
@@ -1,0 +1,40 @@
+use clap::{command, Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "chico")]
+pub(crate) struct CLI {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum Commands {
+    /// Validate the config file content
+    Validate {
+        #[arg(short, long)]
+        config: String,
+    },
+    Run,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use rstest::rstest;
+
+    use super::{Commands, CLI};
+
+    #[rstest]
+    #[case("-c")]
+    #[case("--config")]
+    fn test_validate_command_parsing(#[case] arg: &str) {
+        let args = vec!["chico", "validate", arg, "/path/to/file"];
+        let cli = CLI::try_parse_from(args).unwrap();
+        // Match the parsed command
+
+        match cli.command {
+            Commands::Validate { config } => assert_eq!(config, "/path/to/file"),
+            _ => panic!("Expected 'New' command"),
+        }
+    }
+}

--- a/chico_server/src/config.rs
+++ b/chico_server/src/config.rs
@@ -221,9 +221,9 @@ mod tests {
     async fn test_validate_config_file() {
         let result = validate_config_file("path/to/not/exist").await;
         assert!(result.is_err());
-        assert_eq!(
-            result.err().unwrap(),
-            "Failed to read the config file. reason: The system cannot find the path specified. (os error 3)"
-        );
+        assert!(result
+            .err()
+            .unwrap()
+            .contains("Failed to read the config file. reason:"));
     }
 }

--- a/chico_server/src/config.rs
+++ b/chico_server/src/config.rs
@@ -17,7 +17,7 @@ pub(crate) async fn validate_config_file(path: &str) -> Result<(), String> {
 fn parse_with_validate(content: &str) -> Result<(), String> {
     if content.is_empty() {
         return Err(format!(
-            "Failed to parse content. reason : content is empty."
+            "Failed to parse content. reason: content is empty."
         ));
     }
 
@@ -84,7 +84,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap(),
-            "Failed to parse content. reason : content is empty."
+            "Failed to parse content. reason: content is empty."
         );
     }
 
@@ -240,7 +240,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap(),
-            "Failed to parse content. reason : content is empty."
+            "Failed to parse content. reason: content is empty."
         );
     }
 

--- a/chico_server/src/config.rs
+++ b/chico_server/src/config.rs
@@ -1,0 +1,229 @@
+use chico_file::parse_config;
+
+/// Validate the config file content
+pub(crate) async fn validate_config_file(path: &str) -> Result<(), String> {
+    let content = tokio::fs::read_to_string(path).await;
+    if content.is_err() {
+        return Err(format!(
+            "Failed to read the config file. reason: {}",
+            content.err().unwrap()
+        ));
+    }
+
+    let content = content.unwrap();
+    parse_with_validate(&content)
+}
+
+fn parse_with_validate(content: &str) -> Result<(), String> {
+    if content.is_empty() {
+        return Err(format!(
+            "Failed to parse content. reason : content is empty."
+        ));
+    }
+
+    let parse_result = parse_config(content);
+
+    if parse_result.is_err() {
+        return Err(format!(
+            "Failed to parse config file. reason: {}",
+            parse_result.err().unwrap()
+        ));
+    }
+
+    let virtual_hosts = parse_result.unwrap().1;
+
+    if virtual_hosts.is_empty() {
+        return Err(format!(
+            "Failed to parse config file. reason: no virtual hosts found."
+        ));
+    }
+
+    // any logical validation like checking for duplicate domains, routes, etc.
+
+    // checking for duplicate domains
+    let mut domains = vec![];
+    for host in virtual_hosts.iter() {
+        if domains.contains(&host.domain) {
+            return Err(format!(
+                "Failed to parse config file. reason: duplicate domain found: {}",
+                host.domain
+            ));
+        }
+        domains.push(host.domain.clone());
+    }
+
+    // checking for duplicate routes
+    for host in virtual_hosts.iter() {
+        let mut paths = vec![];
+        for route in host.routes.iter() {
+            if paths.contains(&route.path) {
+                return Err(format!(
+                    "Failed to parse config file. reason: duplicate in host {} route found: {}",
+                    host.domain, route.path
+                ));
+            }
+            paths.push(route.path.clone());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::{config::parse_with_validate, validate_config_file};
+
+    #[test]
+    fn test_parse_with_validate_empty_content() {
+        let content = "";
+        let result = parse_with_validate(content);
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            "Failed to parse content. reason : content is empty."
+        );
+    }
+
+    #[rstest]
+    #[case(
+        r#"
+        localhost {
+            route / {
+                file index.html
+            }
+        }
+        localhost {
+            route / {
+                file index.html
+            }
+        }
+        "#,
+        "localhost"
+    )]
+    #[case(
+        r#"
+        localhost {
+            route / {
+                file index.html
+            }
+        }
+        example.com {
+            route / {
+                file index.html
+            }
+        }
+
+        example.com {
+            route / {
+                file index.html
+            }
+        }
+
+        localhost {
+            route / {
+                file index.html
+            }
+        }
+        "#,
+        "example.com"
+    )]
+    fn test_parse_with_validate_duplicate_virtual_hosts(
+        #[case] content: &str,
+        #[case] domain: &str,
+    ) {
+        let result = parse_with_validate(content);
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            format!(
+                "Failed to parse config file. reason: duplicate domain found: {}",
+                domain
+            )
+        );
+    }
+
+    #[rstest]
+    #[case(
+        r#"
+        localhost {
+            route / {
+                file index.html
+            }
+            route /blog {
+                file index.html
+            }
+            route /blog {
+                proxy http://localhost:8080
+            }
+        }
+        "#,
+        "localhost",
+        "/blog"
+    )]
+    #[case(
+        r#"
+        localhost {
+            route / {
+                file index.html
+            }
+        }
+        example.com {
+            route / {
+                file index.html
+            }
+            route /api {
+                proxy http://localhost:8080
+            }
+            route /api {
+                respond 404
+            }
+        }
+        "#,
+        "example.com",
+        "/api"
+    )]
+    fn test_parse_with_validate_duplicate_routes(
+        #[case] content: &str,
+        #[case] domain: &str,
+        #[case] route: &str,
+    ) {
+        let result = parse_with_validate(content);
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            format!(
+                "Failed to parse config file. reason: duplicate in host {} route found: {}",
+                domain, route
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_with_validate_valid_content() {
+        let content = r#"
+        localhost {
+            route / {
+                file index.html
+            }
+        }
+        example.com {
+            route / {
+                file index.html
+            }
+        }
+        "#;
+        let result = parse_with_validate(content);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validate_config_file() {
+        let result = validate_config_file("path/to/not/exist").await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            "Failed to read the config file. reason: The system cannot find the path specified. (os error 3)"
+        );
+    }
+}

--- a/chico_server/src/main.rs
+++ b/chico_server/src/main.rs
@@ -17,6 +17,7 @@ async fn main() {
                     eprintln!("{}", err);
                     exit(1);
                 });
+            println!("✅✅✅ Specified config is valid.");
             exit(0);
         }
     }

--- a/chico_server/src/main.rs
+++ b/chico_server/src/main.rs
@@ -1,110 +1,23 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
+use std::process::exit;
 
-use chico_file::parse_config;
-fn main() {
-    let input = r#"
-    # This is comment
-    # This is comment
-
-    # This is comment
-    localhost {
-        # This is comment
-        route / {
-            # This is comment
-            file index.html
-            # This is comment
-            gzip
-            # This is comment
-            log 
-            auth admin password123
-            cache 30s # This is comment
-            # This is comment
+use clap::Parser;
+use config::validate_config_file;
+mod cli;
+mod config;
+#[tokio::main]
+async fn main() {
+    let cli = cli::CLI::parse();
+    match cli.command {
+        cli::Commands::Run => todo!(),
+        cli::Commands::Validate { config } => {
+            validate_config_file(config.as_str())
+                .await
+                .unwrap_or_else(|err| {
+                    eprintln!("{}", err);
+                    exit(1);
+                });
+            exit(0);
         }
-        # This is comment
-        route /api/** {
-            # This is comment
-            proxy http://localhost:3000 # This is comment
-            cors
-            # This is comment
-            rate_limit 10 
-        }
-
-        route /static-response {
-            # This is comment
-            respond "Hello, world!" # This is comment
-        }
-
-        # This is comment
-        route /health {
-            respond 200 # This is comment
-        }
-
-        # This is comment
-        route /secret {
-            respond "Access Denied" 403 # This is comment
-        }
-
-        # This is comment
-        route /old-path {
-            redirect /new-path
-        }
-
-        # This is comment
-        route /old-path-with-status {
-            redirect /new-path 301
-        }
-
-        route /example {
-            respond "<h1>Example</h1>" 200
-            
-            #header +Content-Type text/html
-
-            header =X-Set-Or-Overwrite-Example-Header value
-            header >X-Set-With-defer value
-            header -X-Delete-Example-Header
-            header +X-Add-Example-Header value
-            header ?X-Set-If-NotExist-Example-Header value 
-            header ~X-Replace-Header-Value value replace_with_this
-            header ~>X-Replace-Header-Value-With-Defer value replace_with_this
-
-        }
-
-        # This is comment
-        # This is comment
-
-    }
-    # This is comment
-    example.com {
-        # This is comment
-
-        route /blog/** {
-        # This is comment
-
-            proxy http://blog.example.com
-            gzip
-            cache 5m
-        # This is comment
-
-        }
-        # This is comment
-        
-        route /admin {
-        # This is comment
-
-            proxy http://admin.example.com
-        # This is comment
-
-            auth superuser secret
-        # This is comment
-
-        }
-        # This is comment
-
-    }
-"#;
-
-    match parse_config(input) {
-        Ok((_, config)) => println!("{:#?}", config),
-        Err(err) => eprintln!("Parsing failed: {:?}", err),
     }
 }

--- a/chico_server/tests/cli.rs
+++ b/chico_server/tests/cli.rs
@@ -1,0 +1,2 @@
+#[path = "cli/validate_cmd.rs"]
+mod validate_cmd;

--- a/chico_server/tests/cli/validate_cmd.rs
+++ b/chico_server/tests/cli/validate_cmd.rs
@@ -1,0 +1,78 @@
+use std::io::Write;
+
+use predicates::prelude::*;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_validate_command_without_config_arg_should_return_error() {
+    let mut cmd = assert_cmd::Command::cargo_bin("chico").unwrap();
+    cmd.arg("validate")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "the following required arguments were not provided:\n  --config <CONFIG>",
+        ));
+}
+
+#[test]
+fn test_validate_command_should_return_error_for_invalid_config() {
+    // this content have duplicate host, so it's invalid
+    let content = r#"
+    localhost {
+        route / {
+            file index.html
+        }
+    }
+    localhost {
+        route / {
+            file index.html
+        }
+    }
+    "#;
+
+    let mut temp_file = NamedTempFile::new().unwrap();
+    let _ = temp_file.write_all(content.as_bytes());
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let mut cmd = assert_cmd::Command::cargo_bin("chico").unwrap();
+    cmd.arg("validate")
+        .arg("--config")
+        .arg(file_path)
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "Failed to parse config file. reason: duplicate domain found: localhost",
+        ));
+}
+
+#[test]
+fn test_validate_command_should_return_success_for_valid_config() {
+    let content = r#"
+    localhost {
+        route / {
+            file index.html
+        }
+    }
+    example.com {
+        route / {
+            file index.html
+        }
+    }
+    "#;
+
+    let mut temp_file = NamedTempFile::new().unwrap();
+    let _ = temp_file.write_all(content.as_bytes());
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let mut cmd = assert_cmd::Command::cargo_bin("chico").unwrap();
+    cmd.arg("validate")
+        .arg("--config")
+        .arg(file_path)
+        .assert()
+        .success()
+        .code(0)
+        .stdout(predicate::str::contains(
+            "✅✅✅ Specified config is valid.",
+        ));
+}


### PR DESCRIPTION
This pull request introduces several changes to the `chico_server` and `chico_file` projects, focusing on adding new dependencies, implementing a CLI, and enhancing configuration validation. Below is a summary of the most important changes:

### PR Overview:
Add `validate` command to validate config file content.

### CLI Implementation:
* [`chico_server/src/cli.rs`](diffhunk://#diff-b3d95ab3ddadeab6b7dffcb206ddc6dd3c67df0f293089e6e7efbdf0ce63d99cR1-R40): Introduced a new CLI using `clap` with commands for running and validating the configuration file. Added tests for command parsing.

### Configuration Validation:
* [`chico_server/src/config.rs`](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acR1-R229): Added a function to validate the configuration file content, including checks for duplicate domains and routes. Included comprehensive tests for validation logic.

### Dependency Updates:
* [`chico_server/Cargo.toml`](diffhunk://#diff-b74307ef38f2f493a527aaa8902e10f97c5ee198e8121ee1a5ecf6cf3ddee092R12-R16): Added `clap` and `tokio` as dependencies, and `rstest` as a dev-dependency for testing.

### Code Refactoring:
* [`chico_file/src/lib.rs`](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L14-R14): Changed the visibility of the `types` module to `pub`.
* [`chico_server/src/main.rs`](diffhunk://#diff-9822dec37ad80b99d9e4c88d53e6fb487d551258389170275b0ad7c17f315f11L2-L108): Refactored the `main` function to use the new CLI and configuration validation logic. Removed old code for parsing and handling configuration directly in `main`.

### Development Environment:
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L5-R7): Updated Rust analyzer settings to specify a target directory for cargo and added extra arguments for `checkOnSave`.