### PR TITLE
Add `RespondHandler` implementation

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,7 @@
+[test-groups]
+# Tests with the serial integration test group will run serially, not concurrency.
+serial-integration = { max-threads = 1 }
+
 [profile.ci]
 # Retry tests before failing them.
 retries = { backoff = "exponential", count = 2, delay = "2s" }
@@ -7,6 +11,12 @@ fail-fast = false
 # of the run (for easy scrollability).
 failure-output = "immediate-final"
 
+[[profile.ci.overrides]]
+filter = 'rdeps(test_respond_handler)'
+test-group = 'serial-integration'
+
 # save junit report
 [profile.ci.junit]
 path = "junit.xml"
+
+

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,11 +12,9 @@ fail-fast = false
 failure-output = "immediate-final"
 
 [[profile.ci.overrides]]
-filter = 'rdeps(test_respond_handler)'
+filter = 'test(test_respond_handler)'
 test-group = 'serial-integration'
 
 # save junit report
 [profile.ci.junit]
 path = "junit.xml"
-
-

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,8 +11,9 @@ fail-fast = false
 # of the run (for easy scrollability).
 failure-output = "immediate-final"
 
+# Running tests serially, not concurrency.
 [[profile.ci.overrides]]
-filter = 'test(test_respond_handler)'
+filter = 'test(serial_integration)'
 test-group = 'serial-integration'
 
 # save junit report

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,7 @@
     "editor.defaultFormatter": null,
     "[rust]": {
       "editor.defaultFormatter": "rust-lang.rust-analyzer",
-      "editor.formatOnSave": true,
-      "rust-analyzer.cargo.targetDir": true,
-      "rust-analyzer.checkOnSave.extraArgs":["--target-dir","/tmp/rust-analyzer-check"]
+      "editor.formatOnSave": true
     },
     "cSpell.words": [
       "Alireza",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,9 @@ dependencies = [
  "chico_file",
  "clap",
  "http",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "predicates",
  "rstest",
  "tempfile",
@@ -401,6 +403,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +446,25 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -904,6 +938,12 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +163,8 @@ dependencies = [
  "assert_cmd",
  "chico_file",
  "clap",
+ "http",
+ "hyper",
  "predicates",
  "rstest",
  "tempfile",
@@ -253,6 +261,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +291,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -320,6 +349,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "h2"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +378,60 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
 
 [[package]]
 name = "indexmap"
@@ -346,6 +448,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "libc"
@@ -768,6 +876,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +904,31 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
@@ -803,6 +949,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,10 +143,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
 name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+
+[[package]]
+name = "cc"
+version = "1.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -168,7 +189,9 @@ dependencies = [
  "hyper",
  "hyper-util",
  "predicates",
+ "reqwest",
  "rstest",
+ "serial_test",
  "tempfile",
  "tokio",
 ]
@@ -220,16 +243,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -269,12 +328,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -282,6 +381,23 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -318,12 +434,27 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -449,6 +580,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +632,145 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +779,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -490,6 +799,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,10 +837,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -541,6 +878,23 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -584,6 +938,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
+name = "openssl"
+version = "0.10.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +1005,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +1021,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "predicates"
@@ -720,6 +1130,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "reqwest"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.15",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rstest"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,10 +1246,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
+name = "ryu"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+
+[[package]]
+name = "scc"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -808,6 +1374,61 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -844,10 +1465,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -861,6 +1494,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,7 +1542,7 @@ checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -879,6 +1553,16 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
 
 [[package]]
 name = "tokio"
@@ -910,6 +1594,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +1642,27 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -977,10 +1702,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wait-timeout"
@@ -1013,6 +1773,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1113,4 +1984,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/chico_file/src/types.rs
+++ b/chico_file/src/types.rs
@@ -11,7 +11,7 @@ pub struct Route {
     pub middlewares: Vec<Middleware>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Handler {
     File(String),
     Proxy(String),
@@ -25,6 +25,22 @@ pub enum Handler {
         path: Option<String>,
         status_code: Option<u16>,
     },
+}
+
+impl Handler {
+    pub fn type_name(&self) -> &str {
+        match self {
+            Handler::File(_) => "File",
+            Handler::Proxy(_) => "Proxy",
+            Handler::Dir(_) => "Dir",
+            Handler::Browse(_) => "Browse",
+            Handler::Respond { status: _, body: _ } => "Respond",
+            Handler::Redirect {
+                path: _,
+                status_code: _,
+            } => "Redirect",
+        }
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/chico_server/Cargo.toml
+++ b/chico_server/Cargo.toml
@@ -11,6 +11,8 @@ documentation.workspace = true
 chico_file = { path = "../chico_file" }
 clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1" , features = ["full"]}
+hyper = { version = "1", features = ["full"] }
+http = "1.0"
 
 [dev-dependencies]
 rstest = "0.24.0"

--- a/chico_server/Cargo.toml
+++ b/chico_server/Cargo.toml
@@ -21,7 +21,8 @@ rstest = "0.25.0"
 assert_cmd = "2.0"
 tempfile = "3"
 predicates = "3.1.3"
-
+reqwest = "0.12.12"
+serial_test = "3.2.0"
 
 [lints]
 workspace = true

--- a/chico_server/Cargo.toml
+++ b/chico_server/Cargo.toml
@@ -13,6 +13,8 @@ clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1" , features = ["full"]}
 hyper = { version = "1", features = ["full"] }
 http = "1.0"
+http-body-util = "0.1"
+hyper-util = { version = "0.1", features = ["full"] }
 
 [dev-dependencies]
 rstest = "0.24.0"

--- a/chico_server/resources/test_cases/respond-handler/403_status_code.chf
+++ b/chico_server/resources/test_cases/respond-handler/403_status_code.chf
@@ -1,0 +1,6 @@
+localhost:3000 {
+    route /secret/* {
+        ## This mean http status is (403/forbidden) and response body will be `Access denied`
+        respond "Access denied" 403
+    }
+}

--- a/chico_server/resources/test_cases/respond-handler/403_status_code.chf
+++ b/chico_server/resources/test_cases/respond-handler/403_status_code.chf
@@ -1,6 +1,6 @@
 localhost:3000 {
     route /secret/* {
-        ## This mean http status is (403/forbidden) and response body will be `Access denied`
+        # This mean http status is (403/forbidden) and response body will be `Access denied`
         respond "Access denied" 403
     }
 }

--- a/chico_server/resources/test_cases/respond-handler/ok_with_body_response.chf
+++ b/chico_server/resources/test_cases/respond-handler/ok_with_body_response.chf
@@ -1,6 +1,6 @@
 localhost:3000 {
     route / {
-        ## This mean http status is (200/OK) and response body will be <h1>Example</h1>
+        # This mean http status is (200/OK) and response body will be <h1>Example</h1>
         respond "<h1>Example</h1>" 200
     }
 }

--- a/chico_server/resources/test_cases/respond-handler/ok_with_body_response.chf
+++ b/chico_server/resources/test_cases/respond-handler/ok_with_body_response.chf
@@ -1,0 +1,6 @@
+localhost:3000 {
+    route / {
+        ## This mean http status is (200/OK) and response body will be <h1>Example</h1>
+        respond "<h1>Example</h1>" 200
+    }
+}

--- a/chico_server/resources/test_cases/respond-handler/only_body_response.chf
+++ b/chico_server/resources/test_cases/respond-handler/only_body_response.chf
@@ -1,7 +1,7 @@
 localhost:3000 {
     route / {
-        ## If status code has not be provided the status code will be (200/OK).
-        ## This mean http status is (200/OK) and response body will be <h1>Example</h1>
+        # If status code has not be provided the status code will be (200/OK).
+        # This mean http status is (200/OK) and response body will be <h1>Example</h1>
         respond "<h1>Example</h1>"
     }
 }

--- a/chico_server/resources/test_cases/respond-handler/only_body_response.chf
+++ b/chico_server/resources/test_cases/respond-handler/only_body_response.chf
@@ -1,0 +1,7 @@
+localhost:3000 {
+    route / {
+        ## If status code has not be provided the status code will be (200/OK).
+        ## This mean http status is (200/OK) and response body will be <h1>Example</h1>
+        respond "<h1>Example</h1>"
+    }
+}

--- a/chico_server/resources/test_cases/respond-handler/simple_ok_response.chf
+++ b/chico_server/resources/test_cases/respond-handler/simple_ok_response.chf
@@ -1,6 +1,6 @@
 localhost:3000 {
     route /health {
-        ## This mean http status is (200/OK) with empty response body
+        # This mean http status is (200/OK) with empty response body
         respond 200
     }
 }

--- a/chico_server/resources/test_cases/respond-handler/simple_ok_response.chf
+++ b/chico_server/resources/test_cases/respond-handler/simple_ok_response.chf
@@ -1,0 +1,6 @@
+localhost:3000 {
+    route /health {
+        ## This mean http status is (200/OK) with empty response body
+        respond 200
+    }
+}

--- a/chico_server/src/handlers.rs
+++ b/chico_server/src/handlers.rs
@@ -1,0 +1,47 @@
+use chico_file::types::VirtualHost;
+
+#[allow(dead_code)]
+pub trait RequestHandler {
+    fn handle(_request: hyper::Request<()>) -> hyper::Response<()> {
+        todo!();
+    }
+}
+
+pub struct NullRequestHandler {}
+
+impl RequestHandler for NullRequestHandler {
+    fn handle(_request: hyper::Request<()>) -> hyper::Response<()> {
+        std::todo!();
+    }
+}
+
+#[allow(dead_code)]
+pub fn select_handler(request: &hyper::Request<()>, vhs: Vec<VirtualHost>) -> impl RequestHandler {
+    //todo handle unwrap
+    let host = request.headers().get(http::header::HOST).unwrap();
+    let vh = vhs
+        .iter()
+        .find(|&vh| vh.domain == host.to_str().unwrap())
+        .unwrap();
+
+    let route = vh
+        .routes
+        .iter()
+        .find(|&r| r.path == request.uri().path())
+        .unwrap();
+
+    _ = match route.handler {
+        chico_file::types::Handler::File(_) => todo!(),
+        chico_file::types::Handler::Proxy(_) => todo!(),
+        chico_file::types::Handler::Dir(_) => todo!(),
+        chico_file::types::Handler::Browse(_) => todo!(),
+        chico_file::types::Handler::Respond { status: _, body: _ } => todo!(),
+        chico_file::types::Handler::Redirect {
+            path: _,
+            status_code: _,
+        } => todo!(),
+    };
+
+    #[allow(unreachable_code)]
+    NullRequestHandler {}
+}

--- a/chico_server/src/handlers.rs
+++ b/chico_server/src/handlers.rs
@@ -2,32 +2,30 @@ use chico_file::types::Config;
 
 use crate::{config::ConfigExt, virtual_host::VirtualHostExt};
 use http_body_util::Full;
-use hyper::{body::Bytes, Response};
+use hyper::{
+    body::{Body, Bytes},
+    Response,
+};
 use respond::RespondHandler;
 
 mod respond;
 
-#[allow(dead_code)]
 pub trait RequestHandler {
-    fn handle(&self, _request: hyper::Request<hyper::body::Incoming>) -> Response<Full<Bytes>>;
+    fn handle(&self, _request: hyper::Request<impl Body>) -> Response<Full<Bytes>>;
 }
 
 pub struct NullRequestHandler {}
 
 impl RequestHandler for NullRequestHandler {
-    fn handle(&self, _request: hyper::Request<hyper::body::Incoming>) -> Response<Full<Bytes>> {
+    fn handle(&self, _request: hyper::Request<impl Body>) -> Response<Full<Bytes>> {
         todo!()
     }
 }
 
 #[allow(dead_code)]
-pub fn select_handler(
-    request: &hyper::Request<hyper::body::Incoming>,
-    config: Config,
-) -> Box<dyn RequestHandler> {
+pub fn select_handler(request: &hyper::Request<impl Body>, config: Config) -> HandlerEnum {
     //todo handle unwrap
     let host = request.headers().get(http::header::HOST).unwrap();
-    println!("host: {:?}", host);
     let vh = &config.find_virtual_host(host.to_str().unwrap());
 
     if vh.is_none() {
@@ -44,14 +42,16 @@ pub fn select_handler(
 
     let route = route.unwrap();
 
-    let handler: Box<dyn RequestHandler> = match route.handler {
+    let handler: HandlerEnum = match route.handler {
         chico_file::types::Handler::File(_) => todo!(),
         chico_file::types::Handler::Proxy(_) => todo!(),
         chico_file::types::Handler::Dir(_) => todo!(),
         chico_file::types::Handler::Browse(_) => todo!(),
-        chico_file::types::Handler::Respond { status: _, body: _ } => Box::new(RespondHandler {
-            handler: route.handler.clone(),
-        }),
+        chico_file::types::Handler::Respond { status: _, body: _ } => {
+            HandlerEnum::Respond(RespondHandler {
+                handler: route.handler.clone(),
+            })
+        }
         chico_file::types::Handler::Redirect {
             path: _,
             status_code: _,
@@ -59,4 +59,19 @@ pub fn select_handler(
     };
 
     handler
+}
+
+pub enum HandlerEnum {
+    #[allow(dead_code)]
+    Null(NullRequestHandler),
+    Respond(RespondHandler),
+}
+
+impl RequestHandler for HandlerEnum {
+    fn handle(&self, request: hyper::Request<impl Body>) -> Response<Full<Bytes>> {
+        match self {
+            HandlerEnum::Null(handler) => handler.handle(request),
+            HandlerEnum::Respond(handler) => handler.handle(request),
+        }
+    }
 }

--- a/chico_server/src/handlers.rs
+++ b/chico_server/src/handlers.rs
@@ -1,28 +1,31 @@
 use chico_file::types::VirtualHost;
+use http_body_util::Full;
+use hyper::{body::Bytes, Response};
 use respond::RespondHandler;
 
 mod respond;
 
 #[allow(dead_code)]
 pub trait RequestHandler {
-    fn handle(&self, _request: hyper::Request<()>) -> hyper::Response<()>;
+    fn handle(&self, _request: hyper::Request<hyper::body::Incoming>) -> Response<Full<Bytes>>;
 }
 
 pub struct NullRequestHandler {}
 
 impl RequestHandler for NullRequestHandler {
-    fn handle(&self, _request: hyper::Request<()>) -> hyper::Response<()> {
-        std::todo!();
+    fn handle(&self, _request: hyper::Request<hyper::body::Incoming>) -> Response<Full<Bytes>> {
+        todo!()
     }
 }
 
 #[allow(dead_code)]
 pub fn select_handler(
-    request: &hyper::Request<()>,
+    request: &hyper::Request<hyper::body::Incoming>,
     vhs: Vec<VirtualHost>,
 ) -> Box<dyn RequestHandler> {
     //todo handle unwrap
     let host = request.headers().get(http::header::HOST).unwrap();
+    println!("host: {:?}", host);
     let vh = vhs
         .iter()
         .find(|&vh| vh.domain == host.to_str().unwrap())
@@ -35,13 +38,13 @@ pub fn select_handler(
         .unwrap();
 
     let handler: Box<dyn RequestHandler> = match route.handler {
-        chico_file::types::Handler::File(_) => Box::new(RespondHandler {
-            handler: route.handler.clone(),
-        }),
+        chico_file::types::Handler::File(_) => todo!(),
         chico_file::types::Handler::Proxy(_) => todo!(),
         chico_file::types::Handler::Dir(_) => todo!(),
         chico_file::types::Handler::Browse(_) => todo!(),
-        chico_file::types::Handler::Respond { status: _, body: _ } => todo!(),
+        chico_file::types::Handler::Respond { status: _, body: _ } => Box::new(RespondHandler {
+            handler: route.handler.clone(),
+        }),
         chico_file::types::Handler::Redirect {
             path: _,
             status_code: _,

--- a/chico_server/src/handlers/respond.rs
+++ b/chico_server/src/handlers/respond.rs
@@ -1,23 +1,19 @@
 use chico_file::types;
 use http::{status, Response};
 use http_body_util::Full;
-use hyper::body::Bytes;
+use hyper::body::{Body, Bytes};
 
 use super::RequestHandler;
 
-#[allow(dead_code)]
 pub struct RespondHandler {
     pub handler: types::Handler,
 }
 
 impl RequestHandler for RespondHandler {
-    fn handle(
-        &self,
-        _request: hyper::Request<hyper::body::Incoming>,
-    ) -> hyper::Response<Full<Bytes>> {
+    fn handle(&self, _request: hyper::Request<impl Body>) -> hyper::Response<Full<Bytes>> {
         if let types::Handler::Respond { status, body } = &self.handler {
             let status = status.unwrap_or(status::StatusCode::OK.as_u16());
-            let body = body.as_ref().unwrap_or(&"".to_string()).clone();
+            let body = body.as_ref().unwrap_or(&String::new()).clone();
 
             Response::builder()
                 .status(status)
@@ -28,6 +24,142 @@ impl RequestHandler for RespondHandler {
                 "Only respond handler is supported. Given handler was {:}",
                 self.handler.type_name()
             )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::handlers::RequestHandler;
+    use http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use hyper::body::{Body, Bytes};
+
+    #[tokio::test]
+    async fn test_respond_handler_specified_status_no_body() {
+        use super::RespondHandler;
+
+        let respond_handler = RespondHandler {
+            handler: chico_file::types::Handler::Respond {
+                status: Some(200),
+                body: None,
+            },
+        };
+
+        let request_body: MockBody = MockBody::new(b"");
+
+        let request = Request::builder().body(request_body).unwrap();
+        let response = respond_handler.handle(request);
+
+        let response_body = String::from_utf8(
+            response
+                .body()
+                .clone()
+                .collect()
+                .await
+                .unwrap()
+                .to_bytes()
+                .to_vec(),
+        )
+        .unwrap();
+
+        response.status();
+        assert_eq!(response_body, "");
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_respond_handler_specified_body_no_status() {
+        use super::RespondHandler;
+
+        let respond_handler = RespondHandler {
+            handler: chico_file::types::Handler::Respond {
+                status: None,
+                body: Some(String::from("Hello, world!")),
+            },
+        };
+
+        let request_body: MockBody = MockBody::new(b"Hello, world!");
+
+        let request = Request::builder().body(request_body).unwrap();
+        let response = respond_handler.handle(request);
+
+        let response_body = String::from_utf8(
+            response
+                .body()
+                .clone()
+                .collect()
+                .await
+                .unwrap()
+                .to_bytes()
+                .to_vec(),
+        )
+        .unwrap();
+
+        response.status();
+        assert_eq!(response_body, "Hello, world!");
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_respond_handler_specified_body_specified_status() {
+        use super::RespondHandler;
+
+        let respond_handler = RespondHandler {
+            handler: chico_file::types::Handler::Respond {
+                status: Some(403),
+                body: Some(String::from("Access denied")),
+            },
+        };
+
+        let request_body: MockBody = MockBody::new(b"Access denied");
+
+        let request = Request::builder().body(request_body).unwrap();
+        let response = respond_handler.handle(request);
+
+        let response_body = String::from_utf8(
+            response
+                .body()
+                .clone()
+                .collect()
+                .await
+                .unwrap()
+                .to_bytes()
+                .to_vec(),
+        )
+        .unwrap();
+
+        response.status();
+        assert_eq!(response_body, "Access denied");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    struct MockBody {
+        data: &'static [u8],
+    }
+
+    impl MockBody {
+        fn new(data: &'static [u8]) -> Self {
+            Self { data }
+        }
+    }
+
+    impl Body for MockBody {
+        type Data = Bytes;
+        type Error = hyper::Error;
+
+        fn poll_frame(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+            if self.data.is_empty() {
+                std::task::Poll::Ready(None)
+            } else {
+                let data = self.data;
+                self.data = &[];
+                std::task::Poll::Ready(Some(Ok(hyper::body::Frame::data(Bytes::from(data)))))
+            }
         }
     }
 }

--- a/chico_server/src/handlers/respond.rs
+++ b/chico_server/src/handlers/respond.rs
@@ -96,7 +96,6 @@ mod tests {
         )
         .unwrap();
 
-        response.status();
         assert_eq!(response_body, "Hello, world!");
         assert_eq!(response.status(), StatusCode::OK);
     }
@@ -129,7 +128,6 @@ mod tests {
         )
         .unwrap();
 
-        response.status();
         assert_eq!(response_body, "Access denied");
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }

--- a/chico_server/src/handlers/respond.rs
+++ b/chico_server/src/handlers/respond.rs
@@ -1,5 +1,7 @@
 use chico_file::types;
 use http::{status, Response};
+use http_body_util::Full;
+use hyper::body::Bytes;
 
 use super::RequestHandler;
 
@@ -9,12 +11,18 @@ pub struct RespondHandler {
 }
 
 impl RequestHandler for RespondHandler {
-    fn handle(&self, _request: hyper::Request<()>) -> hyper::Response<()> {
+    fn handle(
+        &self,
+        _request: hyper::Request<hyper::body::Incoming>,
+    ) -> hyper::Response<Full<Bytes>> {
         if let types::Handler::Respond { status, body } = &self.handler {
             let status = status.unwrap_or(status::StatusCode::OK.as_u16());
-            let _body = body.as_ref().unwrap_or(&"".to_string());
+            let body = body.as_ref().unwrap_or(&"".to_string()).clone();
 
-            Response::builder().status(status).body(()).unwrap()
+            Response::builder()
+                .status(status)
+                .body(Full::new(Bytes::from(body)))
+                .unwrap()
         } else {
             unimplemented!(
                 "Only respond handler is supported. Given handler was {:}",

--- a/chico_server/src/handlers/respond.rs
+++ b/chico_server/src/handlers/respond.rs
@@ -1,0 +1,25 @@
+use chico_file::types;
+use http::{status, Response};
+
+use super::RequestHandler;
+
+#[allow(dead_code)]
+pub struct RespondHandler {
+    pub handler: types::Handler,
+}
+
+impl RequestHandler for RespondHandler {
+    fn handle(&self, _request: hyper::Request<()>) -> hyper::Response<()> {
+        if let types::Handler::Respond { status, body } = &self.handler {
+            let status = status.unwrap_or(status::StatusCode::OK.as_u16());
+            let _body = body.as_ref().unwrap_or(&"".to_string());
+
+            Response::builder().status(status).body(()).unwrap()
+        } else {
+            unimplemented!(
+                "Only respond handler is supported. Given handler was {:}",
+                self.handler.type_name()
+            )
+        }
+    }
+}

--- a/chico_server/src/handlers/respond.rs
+++ b/chico_server/src/handlers/respond.rs
@@ -21,7 +21,7 @@ impl RequestHandler for RespondHandler {
                 .unwrap()
         } else {
             unimplemented!(
-                "Only respond handler is supported. Given handler was {:}",
+                "Only respond handler is supported. Given handler was {}",
                 self.handler.type_name()
             )
         }
@@ -64,7 +64,6 @@ mod tests {
         )
         .unwrap();
 
-        response.status();
         assert_eq!(response_body, "");
         assert_eq!(response.status(), StatusCode::OK);
     }

--- a/chico_server/src/main.rs
+++ b/chico_server/src/main.rs
@@ -1,10 +1,8 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
-
-use std::process::exit;
-
 use clap::Parser;
 use config::validate_config_file;
 use server::run_server;
+use std::process::exit;
 mod cli;
 mod config;
 mod handlers;

--- a/chico_server/src/main.rs
+++ b/chico_server/src/main.rs
@@ -1,8 +1,16 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
-use std::process::exit;
+use chico_file::types::{Handler, Route, VirtualHost};
+use handlers::select_handler;
+use http::{Request, Response};
+use http_body_util::Full;
+use hyper::{body::Bytes, service::service_fn};
+use std::{convert::Infallible, net::SocketAddr, process::exit};
 
 use clap::Parser;
 use config::validate_config_file;
+use hyper::server::conn::http1;
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpListener;
 mod cli;
 mod config;
 mod handlers;
@@ -10,7 +18,31 @@ mod handlers;
 async fn main() {
     let cli = cli::CLI::parse();
     match cli.command {
-        cli::Commands::Run => todo!(),
+        cli::Commands::Run => {
+            let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+
+            let listener = TcpListener::bind(addr).await.unwrap();
+
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+
+                // Use an adapter to access something implementing `tokio::io` traits as if they implement
+                // `hyper::rt` IO traits.
+                let io = TokioIo::new(stream);
+
+                // Spawn a tokio task to serve multiple connections concurrently
+                tokio::task::spawn(async move {
+                    // Finally, we bind the incoming connection to our `hello` service
+                    if let Err(err) = http1::Builder::new()
+                        // `service_fn` converts our function in a `Service`
+                        .serve_connection(io, service_fn(handle_request))
+                        .await
+                    {
+                        eprintln!("Error serving connection: {:?}", err);
+                    }
+                });
+            }
+        }
         cli::Commands::Validate { config } => {
             validate_config_file(config.as_str())
                 .await
@@ -22,4 +54,23 @@ async fn main() {
             exit(0);
         }
     }
+}
+
+async fn handle_request(
+    request: Request<hyper::body::Incoming>,
+) -> Result<Response<Full<Bytes>>, Infallible> {
+    let vhs = vec![VirtualHost {
+        domain: "localhost:3000".to_string(),
+        routes: vec![Route {
+            handler: Handler::Respond {
+                status: Some(200),
+                body: Some("Hello".to_string()),
+            },
+            middlewares: vec![],
+            path: "/".to_string(),
+        }],
+    }];
+    let res = select_handler(&request, vhs).handle(request);
+
+    Ok(res)
 }

--- a/chico_server/src/main.rs
+++ b/chico_server/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use config::validate_config_file;
 mod cli;
 mod config;
+mod handlers;
 #[tokio::main]
 async fn main() {
     let cli = cli::CLI::parse();

--- a/chico_server/src/server.rs
+++ b/chico_server/src/server.rs
@@ -7,6 +7,8 @@ use hyper::{body::Bytes, server::conn::http1, service::service_fn};
 use hyper_util::rt::TokioIo;
 use tokio::net::TcpListener;
 
+use crate::handlers::select_handler;
+
 pub async fn run_server(config: Config) {
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
 
@@ -51,8 +53,9 @@ pub async fn run_server(config: Config) {
 }
 
 async fn handle_request(
-    _request: Request<hyper::body::Incoming>,
-    _config: Config,
+    request: Request<hyper::body::Incoming>,
+    config: Config,
 ) -> Result<Response<Full<Bytes>>, Infallible> {
-    todo!()
+    let res = select_handler(&request, config).handle(request);
+    Ok(res)
 }

--- a/chico_server/src/server.rs
+++ b/chico_server/src/server.rs
@@ -1,10 +1,9 @@
-use std::{convert::Infallible, net::SocketAddr};
-
 use chico_file::types::Config;
 use http::{Request, Response};
 use http_body_util::Full;
 use hyper::{body::Bytes, server::conn::http1, service::service_fn};
 use hyper_util::rt::TokioIo;
+use std::{convert::Infallible, net::SocketAddr};
 use tokio::net::TcpListener;
 
 use crate::handlers::select_handler;

--- a/chico_server/src/server.rs
+++ b/chico_server/src/server.rs
@@ -1,12 +1,16 @@
 use chico_file::types::Config;
 use http::{Request, Response};
 use http_body_util::Full;
-use hyper::{body::Bytes, server::conn::http1, service::service_fn};
+use hyper::{
+    body::{Body, Bytes},
+    server::conn::http1,
+    service::service_fn,
+};
 use hyper_util::rt::TokioIo;
 use std::{convert::Infallible, net::SocketAddr};
 use tokio::net::TcpListener;
 
-use crate::handlers::select_handler;
+use crate::handlers::{select_handler, RequestHandler};
 
 pub async fn run_server(config: Config) {
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
@@ -52,7 +56,7 @@ pub async fn run_server(config: Config) {
 }
 
 async fn handle_request(
-    request: Request<hyper::body::Incoming>,
+    request: Request<impl Body>,
     config: Config,
 ) -> Result<Response<Full<Bytes>>, Infallible> {
     let res = select_handler(&request, config).handle(request);

--- a/chico_server/src/server.rs
+++ b/chico_server/src/server.rs
@@ -22,6 +22,8 @@ pub async fn run_server(config: Config) {
             return;
         }
     };
+    println!("Start listening requests on 3000");
+
     loop {
         let (stream, _) = match listener.accept().await {
             Ok(conn) => conn,

--- a/chico_server/tests/server.rs
+++ b/chico_server/tests/server.rs
@@ -25,8 +25,8 @@ impl ServerFixture {
     }
 
     pub fn stop_app(&mut self) {
-        let _ = &self.process.kill().unwrap();
-        _ = &self.process.wait();
+        self.process.kill().unwrap();
+        self.process.wait().unwrap();
         self.wait_for_port_release();
     }
 

--- a/chico_server/tests/server.rs
+++ b/chico_server/tests/server.rs
@@ -1,8 +1,5 @@
-use http::StatusCode;
-use serial_test::serial;
 use std::{
     io::{BufRead, BufReader},
-    path::Path,
     process::Stdio,
     time::Duration,
 };
@@ -69,65 +66,75 @@ impl ServerFixture {
     }
 }
 
-#[tokio::test]
-#[serial]
-async fn test_respond_handler_ok_with_body_response() {
-    let config_file_path =
-        Path::new("resources/test_cases/respond-handler/ok_with_body_response.chf");
-    assert!(config_file_path.exists());
+/// We use #[serial_test::serial] to run tests (with cargo test) in this module serially. Running these tests concurrency case failure.
+/// We use serial_integration name to run tests (with nextest) in this module serially. We configured nextest to run these these serially. See .config/nextest.toml.
+#[serial_test::serial]
+mod serial_integration {
+    use std::path::Path;
 
-    let mut app = ServerFixture::run_app(config_file_path);
-    app.wait_for_start();
-    let response = reqwest::get("http://localhost:3000/").await.unwrap();
-    app.stop_app();
+    use http::StatusCode;
 
-    assert_eq!(&response.status(), &StatusCode::OK);
-    assert_eq!(&response.text().await.unwrap(), "<h1>Example</h1>");
-}
+    use crate::ServerFixture;
 
-#[tokio::test]
-#[serial]
-async fn test_respond_handler_403_status_code() {
-    let config_file_path = Path::new("resources/test_cases/respond-handler/403_status_code.chf");
-    assert!(config_file_path.exists());
+    #[tokio::test]
+    async fn test_respond_handler_ok_with_body_response() {
+        let config_file_path =
+            Path::new("resources/test_cases/respond-handler/ok_with_body_response.chf");
+        assert!(config_file_path.exists());
 
-    let mut app = ServerFixture::run_app(config_file_path);
-    app.wait_for_start();
-    let response = reqwest::get("http://localhost:3000/secret/data")
-        .await
-        .unwrap();
-    app.stop_app();
+        let mut app = ServerFixture::run_app(config_file_path);
+        app.wait_for_start();
+        let response = reqwest::get("http://localhost:3000/").await.unwrap();
+        app.stop_app();
 
-    assert_eq!(&response.status(), &StatusCode::FORBIDDEN);
-    assert_eq!(&response.text().await.unwrap(), "Access denied");
-}
+        assert_eq!(&response.status(), &StatusCode::OK);
+        assert_eq!(&response.text().await.unwrap(), "<h1>Example</h1>");
+    }
 
-#[tokio::test]
-#[serial]
-async fn test_respond_handler_only_body_response() {
-    let config_file_path = Path::new("resources/test_cases/respond-handler/only_body_response.chf");
-    assert!(config_file_path.exists());
+    #[tokio::test]
+    async fn test_respond_handler_403_status_code() {
+        let config_file_path =
+            Path::new("resources/test_cases/respond-handler/403_status_code.chf");
+        assert!(config_file_path.exists());
 
-    let mut app = ServerFixture::run_app(config_file_path);
-    app.wait_for_start();
-    let response = reqwest::get("http://localhost:3000/").await.unwrap();
-    app.stop_app();
+        let mut app = ServerFixture::run_app(config_file_path);
+        app.wait_for_start();
+        let response = reqwest::get("http://localhost:3000/secret/data")
+            .await
+            .unwrap();
+        app.stop_app();
 
-    assert_eq!(&response.status(), &StatusCode::OK);
-    assert_eq!(&response.text().await.unwrap(), "<h1>Example</h1>");
-}
+        assert_eq!(&response.status(), &StatusCode::FORBIDDEN);
+        assert_eq!(&response.text().await.unwrap(), "Access denied");
+    }
 
-#[tokio::test]
-#[serial]
-async fn test_respond_handler_simple_ok_response() {
-    let config_file_path = Path::new("resources/test_cases/respond-handler/simple_ok_response.chf");
-    assert!(config_file_path.exists());
+    #[tokio::test]
+    async fn test_respond_handler_only_body_response() {
+        let config_file_path =
+            Path::new("resources/test_cases/respond-handler/only_body_response.chf");
+        assert!(config_file_path.exists());
 
-    let mut app = ServerFixture::run_app(config_file_path);
-    app.wait_for_start();
-    let response = reqwest::get("http://localhost:3000/health").await.unwrap();
-    app.stop_app();
+        let mut app = ServerFixture::run_app(config_file_path);
+        app.wait_for_start();
+        let response = reqwest::get("http://localhost:3000/").await.unwrap();
+        app.stop_app();
 
-    assert_eq!(&response.status(), &StatusCode::OK);
-    assert_eq!(&response.text().await.unwrap(), "");
+        assert_eq!(&response.status(), &StatusCode::OK);
+        assert_eq!(&response.text().await.unwrap(), "<h1>Example</h1>");
+    }
+
+    #[tokio::test]
+    async fn test_respond_handler_simple_ok_response() {
+        let config_file_path =
+            Path::new("resources/test_cases/respond-handler/simple_ok_response.chf");
+        assert!(config_file_path.exists());
+
+        let mut app = ServerFixture::run_app(config_file_path);
+        app.wait_for_start();
+        let response = reqwest::get("http://localhost:3000/health").await.unwrap();
+        app.stop_app();
+
+        assert_eq!(&response.status(), &StatusCode::OK);
+        assert_eq!(&response.text().await.unwrap(), "");
+    }
 }

--- a/chico_server/tests/server.rs
+++ b/chico_server/tests/server.rs
@@ -1,0 +1,91 @@
+use http::StatusCode;
+use serial_test::serial;
+use std::path::Path;
+
+pub(crate) struct ServerFixture {
+    process: std::process::Child,
+}
+
+impl ServerFixture {
+    pub fn run_app<T: AsRef<std::ffi::OsStr>>(config_path: T) -> ServerFixture {
+        use assert_cmd::cargo::CommandCargoExt;
+
+        let process = std::process::Command::cargo_bin("chico")
+            .expect("Failed to find binary")
+            .arg("run")
+            .arg("--config")
+            .arg(config_path)
+            .spawn()
+            .expect("Failed to start server");
+
+        ServerFixture { process }
+    }
+
+    pub fn stop_app(&mut self) {
+        _ = &self.process.kill();
+        _ = &self.process.wait();
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_respond_handler_ok_with_body_response() {
+    let config_file_path =
+        Path::new("resources/test_cases/respond-handler/ok_with_body_response.chf");
+    assert!(config_file_path.exists());
+
+    let mut app = ServerFixture::run_app(config_file_path);
+
+    let response = reqwest::get("http://localhost:3000/").await.unwrap();
+    assert_eq!(&response.status(), &StatusCode::OK);
+    assert_eq!(&response.text().await.unwrap(), "<h1>Example</h1>");
+
+    app.stop_app();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_respond_handler_403_status_code() {
+    let config_file_path = Path::new("resources/test_cases/respond-handler/403_status_code.chf");
+    assert!(config_file_path.exists());
+
+    let mut app = ServerFixture::run_app(config_file_path);
+
+    let response = reqwest::get("http://localhost:3000/secret/data")
+        .await
+        .unwrap();
+    assert_eq!(&response.status(), &StatusCode::FORBIDDEN);
+    assert_eq!(&response.text().await.unwrap(), "Access denied");
+
+    app.stop_app();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_respond_handler_only_body_response() {
+    let config_file_path = Path::new("resources/test_cases/respond-handler/only_body_response.chf");
+    assert!(config_file_path.exists());
+
+    let mut app = ServerFixture::run_app(config_file_path);
+
+    let response = reqwest::get("http://localhost:3000/").await.unwrap();
+    assert_eq!(&response.status(), &StatusCode::OK);
+    assert_eq!(&response.text().await.unwrap(), "<h1>Example</h1>");
+
+    app.stop_app();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_respond_handler_simple_ok_response() {
+    let config_file_path = Path::new("resources/test_cases/respond-handler/simple_ok_response.chf");
+    assert!(config_file_path.exists());
+
+    let mut app = ServerFixture::run_app(config_file_path);
+
+    let response = reqwest::get("http://localhost:3000/health").await.unwrap();
+    assert_eq!(&response.status(), &StatusCode::OK);
+    assert_eq!(&response.text().await.unwrap(), "");
+
+    app.stop_app();
+}


### PR DESCRIPTION
This pull request introduces several changes to the `chico_server` project, focusing on adding new response handlers, updating configurations, and enhancing test coverage. The most important changes include the addition of the `RespondHandler` implementation, updates to the `select_handler` function, and the introduction of new test cases for the response handlers.

### Response Handlers Implementation:

* [`chico_server/src/handlers.rs`](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010R4-R26): Added `RespondHandler` to handle HTTP responses with status and body, and updated `RequestHandler` and `select_handler` to integrate the new handler. [[1]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010R4-R26) [[2]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L40-R76)
* [`chico_server/src/handlers/respond.rs`](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fR1-R162): Implemented the `RespondHandler` struct and its `handle` method to generate HTTP responses based on the provided status and body.

### Configuration Updates:

* [`.config/nextest.toml`](diffhunk://#diff-3e429424057e0b2a83fafc6e8942f4c05b63f4d977548e51535f8d86be8f9613R1-R4): Added a new test group `serial-integration` to run tests serially and updated the CI profile to include this test group. [[1]](diffhunk://#diff-3e429424057e0b2a83fafc6e8942f4c05b63f4d977548e51535f8d86be8f9613R1-R4) [[2]](diffhunk://#diff-3e429424057e0b2a83fafc6e8942f4c05b63f4d977548e51535f8d86be8f9613R14-R18)

### Test Enhancements:

* [`chico_server/tests/server.rs`](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988R1-R140): Introduced new integration tests for various response scenarios using `RespondHandler`, ensuring correct status codes and response bodies.

### Additional Changes:

* [`chico_server/Cargo.toml`](diffhunk://#diff-b74307ef38f2f493a527aaa8902e10f97c5ee198e8121ee1a5ecf6cf3ddee092L24-R25): Added new dependencies `reqwest` and `serial_test` for handling HTTP requests and running tests serially.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L5-R5): Simplified the Rust analyzer settings by removing unnecessary configurations.