### PR TITLE
Wrap virtual host from parse_config in Config struct

### DIFF
--- a/chico_file/src/types.rs
+++ b/chico_file/src/types.rs
@@ -1,4 +1,9 @@
 #[derive(Debug, PartialEq)]
+pub struct Config {
+    pub virtual_hosts: Vec<VirtualHost>,
+}
+
+#[derive(Debug, PartialEq)]
 pub struct VirtualHost {
     pub domain: String,
     pub routes: Vec<Route>,

--- a/chico_server/src/config.rs
+++ b/chico_server/src/config.rs
@@ -30,7 +30,7 @@ fn parse_with_validate(content: &str) -> Result<(), String> {
         ));
     }
 
-    let virtual_hosts = parse_result.unwrap().1;
+    let virtual_hosts = parse_result.unwrap().1.virtual_hosts;
 
     if virtual_hosts.is_empty() {
         return Err(format!(


### PR DESCRIPTION
This pull request includes several changes to the `chico_file` and `chico_server` modules, focusing on refactoring the configuration parsing logic to use a new `Config` struct and updating the corresponding tests.

### PR overview:
Wrap virtual host from parse_config in Config struct for adding other configurations like global configuration that we want to add in future.

Refactoring configuration parsing:

* [`chico_file/src/lib.rs`](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L253-R264): Updated the `parse_config` function to return a `Config` struct instead of a `Vec<VirtualHost>`.
* [`chico_file/src/types.rs`](diffhunk://#diff-3d833090db79afaf4fc52838ae453df7eb25e94583a4e5b561b30db6c33216caR1-R5): Added a new `Config` struct with a `virtual_hosts` field.

Test updates:

* [`chico_file/src/lib.rs`](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L1172-R1181): Modified various test cases to expect a `Config` struct containing `virtual_hosts` instead of a `Vec<VirtualHost>`. [[1]](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L1172-R1181) [[2]](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L1188-R1206) [[3]](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L1219-R1231) [[4]](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109R1249) [[5]](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L1262-R1276) [[6]](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109R1294) [[7]](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L1300-R1324) [[8]](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L1431-R1449) [[9]](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109R1598)

Code formatting:

* [`chico_file/src/lib.rs`](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L1507-R1526): Reformatted long string literals in middleware header tests for better readability. [[1]](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L1507-R1526) [[2]](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L1531-R1551) [[3]](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L1543-R1564)

Configuration validation:

* [`chico_server/src/config.rs`](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acL33-R33): Updated the `parse_with_validate` function to access `virtual_hosts` from the new `Config` struct.