### PR TITLE
Add Ability to find `*` path base

### DIFF
--- a/chico_file/src/types.rs
+++ b/chico_file/src/types.rs
@@ -9,14 +9,14 @@ pub struct VirtualHost {
     pub routes: Vec<Route>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Route {
     pub path: String,
     pub handler: Handler,
     pub middlewares: Vec<Middleware>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Handler {
     File(String),
     Proxy(String),
@@ -32,7 +32,7 @@ pub enum Handler {
     },
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Middleware {
     Gzip,
     Cors,

--- a/chico_server/src/config.rs
+++ b/chico_server/src/config.rs
@@ -4,12 +4,12 @@ use chico_file::{
 };
 
 pub trait ConfigExt {
-    fn find_virtual_host(&self, path: String) -> Option<&VirtualHost>;
+    fn find_virtual_host(&self, path: &str) -> Option<&VirtualHost>;
     // Define trait methods here
 }
 
 impl ConfigExt for Config {
-    fn find_virtual_host(&self, path: String) -> Option<&VirtualHost> {
+    fn find_virtual_host(&self, path: &str) -> Option<&VirtualHost> {
         //todo: do more advance search and pattern matching for virtual host
 
         let vh = self.virtual_hosts.iter().find(|&vh| vh.domain == path);

--- a/chico_server/src/config.rs
+++ b/chico_server/src/config.rs
@@ -1,4 +1,22 @@
-use chico_file::parse_config;
+use chico_file::{
+    parse_config,
+    types::{Config, VirtualHost},
+};
+
+pub trait ConfigExt {
+    fn find_virtual_host(&self, path: String) -> Option<&VirtualHost>;
+    // Define trait methods here
+}
+
+impl ConfigExt for Config {
+    fn find_virtual_host(&self, path: String) -> Option<&VirtualHost> {
+        //todo: do more advance search and pattern matching for virtual host
+
+        let vh = self.virtual_hosts.iter().find(|&vh| vh.domain == path);
+        vh
+    }
+    // Implement trait methods here
+}
 
 /// Validate the config file content
 pub(crate) async fn validate_config_file(path: &str) -> Result<(), String> {

--- a/chico_server/src/config.rs
+++ b/chico_server/src/config.rs
@@ -5,17 +5,14 @@ use chico_file::{
 
 pub trait ConfigExt {
     fn find_virtual_host(&self, path: &str) -> Option<&VirtualHost>;
-    // Define trait methods here
 }
 
 impl ConfigExt for Config {
     fn find_virtual_host(&self, path: &str) -> Option<&VirtualHost> {
         //todo: do more advance search and pattern matching for virtual host
-
         let vh = self.virtual_hosts.iter().find(|&vh| vh.domain == path);
         vh
     }
-    // Implement trait methods here
 }
 
 /// Validate the config file content

--- a/chico_server/src/handlers.rs
+++ b/chico_server/src/handlers.rs
@@ -21,7 +21,7 @@ impl RequestHandler for NullRequestHandler {
 pub fn select_handler(request: &hyper::Request<()>, config: Config) -> impl RequestHandler {
     //todo handle unwrap
     let host = request.headers().get(http::header::HOST).unwrap();
-    let vh = &config.find_virtual_host(host.to_str().unwrap().to_string());
+    let vh = &config.find_virtual_host(host.to_str().unwrap());
 
     if vh.is_none() {
         todo!("abort connection in this case");
@@ -29,7 +29,7 @@ pub fn select_handler(request: &hyper::Request<()>, config: Config) -> impl Requ
 
     let vh = vh.unwrap();
 
-    let route = vh.find_route(request.uri().path().to_string());
+    let route = vh.find_route(request.uri().path());
 
     if route.is_none() {
         todo!("abort connection in this case");

--- a/chico_server/src/main.rs
+++ b/chico_server/src/main.rs
@@ -6,6 +6,7 @@ use config::validate_config_file;
 mod cli;
 mod config;
 mod handlers;
+mod virtual_host;
 #[tokio::main]
 async fn main() {
     let cli = cli::CLI::parse();

--- a/chico_server/src/virtual_host.rs
+++ b/chico_server/src/virtual_host.rs
@@ -36,7 +36,6 @@ mod tests {
     #[case("/api/*", "/api/products/get")]
     #[case("/api/products/*", "/api/products/get")]
     #[case("/api/products/get/*", "/api/products/get/1")]
-
     fn test_find_route_success(#[case] path: &str, #[case] search_value: &str) {
         use crate::virtual_host::VirtualHostExt;
         use chico_file::types::{Handler, Route, VirtualHost};

--- a/chico_server/src/virtual_host.rs
+++ b/chico_server/src/virtual_host.rs
@@ -1,11 +1,11 @@
 use chico_file::types::{Route, VirtualHost};
 
 pub trait VirtualHostExt {
-    fn find_route(&self, path: String) -> Option<&Route>;
+    fn find_route(&self, path: &str) -> Option<&Route>;
 }
 
 impl VirtualHostExt for VirtualHost {
-    fn find_route(&self, path: String) -> Option<&Route> {
+    fn find_route(&self, path: &str) -> Option<&Route> {
         //todo: do more advance search and pattern matching for request path
         let route = self.routes.iter().find(|&r| {
             if r.path.ends_with("/*") {
@@ -52,10 +52,7 @@ mod tests {
             routes: vec![route1.clone()],
         };
 
-        assert_eq!(
-            Some(&route1),
-            virtual_hosts.find_route(search_value.to_string())
-        )
+        assert_eq!(Some(&route1), virtual_hosts.find_route(search_value))
     }
 
     #[rstest]
@@ -83,6 +80,6 @@ mod tests {
             routes: vec![route1.clone()],
         };
 
-        assert_eq!(None, virtual_hosts.find_route(search_value.to_string()))
+        assert_eq!(None, virtual_hosts.find_route(search_value))
     }
 }

--- a/chico_server/src/virtual_host.rs
+++ b/chico_server/src/virtual_host.rs
@@ -1,0 +1,88 @@
+use chico_file::types::{Route, VirtualHost};
+
+pub trait VirtualHostExt {
+    fn find_route(&self, path: String) -> Option<&Route>;
+}
+
+impl VirtualHostExt for VirtualHost {
+    fn find_route(&self, path: String) -> Option<&Route> {
+        //todo: do more advance search and pattern matching for request path
+        let route = self.routes.iter().find(|&r| {
+            if r.path.ends_with("/*") {
+                let asterisk_index = r.path.rfind("*").unwrap();
+                path.starts_with(&r.path[..asterisk_index])
+            } else {
+                r.path == path
+            }
+        });
+        route
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("/", "/")]
+    #[case("/blog", "/blog")]
+    #[case("/blog/*", "/blog/post1")]
+    #[case("/*", "/blog")]
+    #[case("/*", "/blog/post1")]
+    #[case("/*", "/api")]
+    #[case("/*", "/api/products")]
+    #[case("/*", "/api/products/get")]
+    #[case("/api/*", "/api/products/get")]
+    #[case("/api/products/*", "/api/products/get")]
+    #[case("/api/products/get/*", "/api/products/get/1")]
+
+    fn test_find_route_success(#[case] path: &str, #[case] search_value: &str) {
+        use crate::virtual_host::VirtualHostExt;
+        use chico_file::types::{Handler, Route, VirtualHost};
+
+        let route1 = Route {
+            handler: Handler::File("".to_string()),
+            middlewares: vec![],
+            path: path.to_string(),
+        };
+
+        let virtual_hosts = VirtualHost {
+            domain: "".to_string(),
+            routes: vec![route1.clone()],
+        };
+
+        assert_eq!(
+            Some(&route1),
+            virtual_hosts.find_route(search_value.to_string())
+        )
+    }
+
+    #[rstest]
+    #[case("/", "/blog")]
+    #[case("/blog", "/blog/posts")]
+    #[case("/blog/", "/blog/posts")]
+    #[case("/blog/posts", "/blog/posts/post1")]
+    #[case("/api/prod", "/api/products")]
+    #[case("/", "/api/products/get")]
+    #[case("/api/products/*", "/api")]
+    #[case("/api/products", "/api/products/get")]
+    #[case("/api/products/get/*", "/api/products/get")]
+    fn test_find_route_fail(#[case] path: &str, #[case] search_value: &str) {
+        use crate::virtual_host::VirtualHostExt;
+        use chico_file::types::{Handler, Route, VirtualHost};
+
+        let route1 = Route {
+            handler: Handler::File("".to_string()),
+            middlewares: vec![],
+            path: path.to_string(),
+        };
+
+        let virtual_hosts = VirtualHost {
+            domain: "".to_string(),
+            routes: vec![route1.clone()],
+        };
+
+        assert_eq!(None, virtual_hosts.find_route(search_value.to_string()))
+    }
+}


### PR DESCRIPTION
This pull request introduces several enhancements and refactors to the `chico_server` and `chico_file` modules, primarily focusing on adding new traits for better configuration and route handling. The most important changes include the addition of `ConfigExt` and `VirtualHostExt` traits, modifications to the `select_handler` function, and updates to existing structs and enums to derive the `Clone` trait.

### PR overview
Add the Ability to find `*` path base. 
For example, we can pick a handler for incoming requests with path `/api/products` when configured `route.path` be `/api/*`.

Enhancements to configuration and routing:

* [`chico_server/src/config.rs`](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acL1-R19): Added `ConfigExt` trait with a method to find a virtual host by domain. Implemented this trait for the `Config` struct.

* [`chico_server/src/virtual_host.rs`](diffhunk://#diff-a669370440416a9ed9ef863366697194a17ed33d44e02447d14f54fe292f4e3fR1-R88): Added `VirtualHostExt` trait with a method to find a route by path. Implemented this trait for the `VirtualHost` struct. Included tests for route matching.

Refactoring:

* [`chico_server/src/handlers.rs`](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L19-R38): Updated `select_handler` function to use the new `ConfigExt` and `VirtualHostExt` traits for better abstraction and cleaner code.

* [`chico_server/src/main.rs`](diffhunk://#diff-9822dec37ad80b99d9e4c88d53e6fb487d551258389170275b0ad7c17f315f11R9): Added `mod virtual_host;` to include the new virtual host extension module.

Struct and enum updates:

* [`chico_file/src/types.rs`](diffhunk://#diff-3d833090db79afaf4fc52838ae453df7eb25e94583a4e5b561b30db6c33216caL12-R19): Updated `Route`, `Handler`, and `Middleware` to derive the `Clone` trait, facilitating easier copying of these types. [[1]](diffhunk://#diff-3d833090db79afaf4fc52838ae453df7eb25e94583a4e5b561b30db6c33216caL12-R19) [[2]](diffhunk://#diff-3d833090db79afaf4fc52838ae453df7eb25e94583a4e5b561b30db6c33216caL35-R35)