### PR TITLE
Add `run` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,9 @@ dependencies = [
  "chico_file",
  "clap",
  "http",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "predicates",
  "rstest",
  "tempfile",
@@ -401,6 +403,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +446,25 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -904,6 +938,12 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/chico_file/src/types.rs
+++ b/chico_file/src/types.rs
@@ -1,9 +1,9 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Config {
     pub virtual_hosts: Vec<VirtualHost>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct VirtualHost {
     pub domain: String,
     pub routes: Vec<Route>,

--- a/chico_server/Cargo.toml
+++ b/chico_server/Cargo.toml
@@ -13,6 +13,8 @@ clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1" , features = ["full"]}
 hyper = { version = "1", features = ["full"] }
 http = "1.0"
+http-body-util = "0.1"
+hyper-util = { version = "0.1", features = ["full"] }
 
 [dev-dependencies]
 rstest = "0.24.0"

--- a/chico_server/src/cli.rs
+++ b/chico_server/src/cli.rs
@@ -14,7 +14,12 @@ pub(crate) enum Commands {
         #[arg(short, long)]
         config: String,
     },
-    Run,
+    /// Run the server
+    /// This command will block executing shell
+    Run {
+        #[arg(short, long)]
+        config: String,
+    },
 }
 
 #[cfg(test)]
@@ -35,6 +40,20 @@ mod tests {
         match cli.command {
             Commands::Validate { config } => assert_eq!(config, "/path/to/file"),
             _ => panic!("Expected 'Validate' command"),
+        }
+    }
+
+    #[rstest]
+    #[case("-c")]
+    #[case("--config")]
+    fn test_run_command_parsing(#[case] arg: &str) {
+        let args = vec!["chico", "run", arg, "/path/to/file"];
+        let cli = CLI::try_parse_from(args).unwrap();
+        // Match the parsed command
+
+        match cli.command {
+            Commands::Run { config } => assert_eq!(config, "/path/to/file"),
+            _ => panic!("Expected 'Run' command"),
         }
     }
 }

--- a/chico_server/src/main.rs
+++ b/chico_server/src/main.rs
@@ -3,15 +3,25 @@ use std::process::exit;
 
 use clap::Parser;
 use config::validate_config_file;
+use server::run_server;
 mod cli;
 mod config;
 mod handlers;
+mod server;
 mod virtual_host;
 #[tokio::main]
 async fn main() {
     let cli = cli::CLI::parse();
     match cli.command {
-        cli::Commands::Run => todo!(),
+        cli::Commands::Run { config } => {
+            let conf = validate_config_file(config.as_str())
+                .await
+                .unwrap_or_else(|err| {
+                    eprintln!("{}", err);
+                    exit(1);
+                });
+            run_server(conf).await
+        }
         cli::Commands::Validate { config } => {
             validate_config_file(config.as_str())
                 .await

--- a/chico_server/src/server.rs
+++ b/chico_server/src/server.rs
@@ -1,0 +1,48 @@
+use std::{convert::Infallible, net::SocketAddr};
+
+use chico_file::types::Config;
+use http::{Request, Response};
+use http_body_util::Full;
+use hyper::{body::Bytes, server::conn::http1, service::service_fn};
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpListener;
+
+pub async fn run_server(config: Config) {
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+
+    let listener = TcpListener::bind(addr).await.unwrap();
+
+    loop {
+        let (stream, _) = listener.accept().await.unwrap();
+
+        // Use an adapter to access something implementing `tokio::io` traits as if they implement
+        // `hyper::rt` IO traits.
+        let io = TokioIo::new(stream);
+
+        // Spawn a tokio task to serve multiple connections concurrently
+        let config_clone = config.clone();
+
+        let service = service_fn(move |req| {
+            let config_clone = config_clone.clone();
+            async move { handle_request(req, config_clone).await }
+        });
+
+        tokio::task::spawn(async move {
+            // Finally, we bind the incoming connection to our `hello` service
+            if let Err(err) = http1::Builder::new()
+                // `service_fn` converts our function in a `Service`
+                .serve_connection(io, service)
+                .await
+            {
+                eprintln!("Error serving connection: {:?}", err);
+            }
+        });
+    }
+}
+
+async fn handle_request(
+    _request: Request<hyper::body::Incoming>,
+    _config: Config,
+) -> Result<Response<Full<Bytes>>, Infallible> {
+    todo!()
+}

--- a/chico_server/src/server.rs
+++ b/chico_server/src/server.rs
@@ -13,8 +13,13 @@ pub async fn run_server(config: Config) {
     let listener = TcpListener::bind(addr).await.unwrap();
 
     loop {
-        let (stream, _) = listener.accept().await.unwrap();
-
+        let (stream, _) = match listener.accept().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                eprintln!("Error accepting connection: {:?}", e);
+                continue;
+            }
+        };
         // Use an adapter to access something implementing `tokio::io` traits as if they implement
         // `hyper::rt` IO traits.
         let io = TokioIo::new(stream);

--- a/chico_server/src/server.rs
+++ b/chico_server/src/server.rs
@@ -10,8 +10,13 @@ use tokio::net::TcpListener;
 pub async fn run_server(config: Config) {
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
 
-    let listener = TcpListener::bind(addr).await.unwrap();
-
+    let listener = match TcpListener::bind(addr).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            eprintln!("Failed to bind to address {}: {:?}", addr, e);
+            return;
+        }
+    };
     loop {
         let (stream, _) = match listener.accept().await {
             Ok(conn) => conn,


### PR DESCRIPTION
This pull request includes several changes to improve the configuration handling and server functionality in the `chico_server` project. The most important changes include adding the `Clone` trait to the `Config` and `VirtualHost` structs, updating the `validate_config_file` function to return a `Config` object, and implementing the `run_server` function to start the server with the given configuration.

### PR overview

Add `run` command to start the web-server. This command will block the executing shell.

### Configuration Handling Improvements:
* [`chico_file/src/types.rs`](diffhunk://#diff-3d833090db79afaf4fc52838ae453df7eb25e94583a4e5b561b30db6c33216caL1-R6): Added the `Clone` trait to `Config` and `VirtualHost` structs.
* [`chico_server/src/config.rs`](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acL19-R19): Updated the `validate_config_file` function to return a `Config` object instead of `()`. [[1]](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acL19-R19) [[2]](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acL32-R32) [[3]](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acL48-R49) [[4]](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acL83-R92)
* [`chico_server/src/config.rs`](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acL285-R310): Modified tests to validate the returned `Config` object.

### Server Functionality:
* [`chico_server/src/main.rs`](diffhunk://#diff-9822dec37ad80b99d9e4c88d53e6fb487d551258389170275b0ad7c17f315f11R6-R24): Updated the `Run` command to validate the configuration file and start the server using the `run_server` function.
* [`chico_server/src/server.rs`](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517R1-R48): Implemented the `run_server` function to start the server and handle incoming connections using the configuration.

### Command Line Interface Enhancements:
* [`chico_server/src/cli.rs`](diffhunk://#diff-b3d95ab3ddadeab6b7dffcb206ddc6dd3c67df0f293089e6e7efbdf0ce63d99cL17-R22): Updated the `Run` command to accept a configuration file path and added tests for command parsing. [[1]](diffhunk://#diff-b3d95ab3ddadeab6b7dffcb206ddc6dd3c67df0f293089e6e7efbdf0ce63d99cL17-R22) [[2]](diffhunk://#diff-b3d95ab3ddadeab6b7dffcb206ddc6dd3c67df0f293089e6e7efbdf0ce63d99cR45-R58)

### Dependency Updates:
* [`chico_server/Cargo.toml`](diffhunk://#diff-b74307ef38f2f493a527aaa8902e10f97c5ee198e8121ee1a5ecf6cf3ddee092R16-R17): Added `http-body-util` and `hyper-util` dependencies.