### PR TITLE
Add `type_name funtion` to Handler enum to get name as &str

### DIFF
--- a/chico_file/src/types.rs
+++ b/chico_file/src/types.rs
@@ -32,6 +32,22 @@ pub enum Handler {
     },
 }
 
+impl Handler {
+    pub fn type_name(&self) -> &str {
+        match self {
+            Handler::File(_) => "File",
+            Handler::Proxy(_) => "Proxy",
+            Handler::Dir(_) => "Dir",
+            Handler::Browse(_) => "Browse",
+            Handler::Respond { status: _, body: _ } => "Respond",
+            Handler::Redirect {
+                path: _,
+                status_code: _,
+            } => "Redirect",
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum Middleware {
     Gzip,
@@ -68,4 +84,36 @@ pub enum HeaderOperator {
     DeferReplace,
     /// Prefix with ? to set a default value for the field. The field is only written if it doesn't yet exist.
     Default,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Handler;
+
+    #[test]
+    fn test_handler_type_name() {
+        let handler = Handler::File(String::new());
+        assert_eq!(handler.type_name(), "File");
+
+        let handler = Handler::Proxy(String::new());
+        assert_eq!(handler.type_name(), "Proxy");
+
+        let handler = Handler::Dir(String::new());
+        assert_eq!(handler.type_name(), "Dir");
+
+        let handler = Handler::Browse(String::new());
+        assert_eq!(handler.type_name(), "Browse");
+
+        let handler = Handler::Respond {
+            status: None,
+            body: None,
+        };
+        assert_eq!(handler.type_name(), "Respond");
+
+        let handler = Handler::Redirect {
+            path: None,
+            status_code: None,
+        };
+        assert_eq!(handler.type_name(), "Redirect");
+    }
 }


### PR DESCRIPTION
This pull request adds functionality to the `Handler` enum in the `chico_file` crate by introducing a method to retrieve the type name of a handler and includes corresponding unit tests to ensure the method works correctly.

Enhancements to `Handler` enum:

* Added a `type_name` method to the `Handler` enum to return a string representation of the handler type. (`chico_file/src/types.rs`, [chico_file/src/types.rsR35-R50](diffhunk://#diff-3d833090db79afaf4fc52838ae453df7eb25e94583a4e5b561b30db6c33216caR35-R50))

Unit tests:

* Introduced unit tests for the `type_name` method to verify the correct type names are returned for various handler variants. (`chico_file/src/types.rs`, [chico_file/src/types.rsR88-R119](diffhunk://#diff-3d833090db79afaf4fc52838ae453df7eb25e94583a4e5b561b30db6c33216caR88-R119))