### PR TITLE
Implement `redirect` handler

### DIFF
--- a/chico_server/resources/test_cases/redirect-handler/not_specified_status.chf
+++ b/chico_server/resources/test_cases/redirect-handler/not_specified_status.chf
@@ -1,0 +1,10 @@
+localhost:3000 {
+
+    route /old-path {
+        redirect /new-path
+    }
+
+    route /new-path {
+        respond "<h1>Redirected from old-path</h1>" 200
+    }   
+}

--- a/chico_server/resources/test_cases/redirect-handler/specified_status.chf
+++ b/chico_server/resources/test_cases/redirect-handler/specified_status.chf
@@ -1,0 +1,10 @@
+localhost:3000 {
+
+    route /old-path {
+        redirect /new-path 301
+    }
+
+    route /new-path {
+        respond "<h1>Redirected from old-path</h1>" 200
+    }   
+}

--- a/chico_server/src/handlers/redirect.rs
+++ b/chico_server/src/handlers/redirect.rs
@@ -15,7 +15,7 @@ impl RequestHandler for RedirectHandler {
     ) -> http::Response<http_body_util::Full<hyper::body::Bytes>> {
         if let types::Handler::Redirect { path, status_code } = &self.handler {
             // Based on chico file path is always some
-            let path = path.clone().expect("Path value expect.");
+            let path = path.clone().expect("Expected path value not provided.");
             let status_code = status_code.unwrap_or(StatusCode::FOUND.as_u16());
 
             Response::builder()
@@ -60,7 +60,7 @@ mod tests {
             response
                 .headers()
                 .get(http::header::LOCATION)
-                .expect("Location header expected")
+                .expect("Expected Location header not provided.")
                 .to_str()
                 .unwrap(),
             "/new-path".to_string()
@@ -86,7 +86,7 @@ mod tests {
             response
                 .headers()
                 .get(http::header::LOCATION)
-                .expect("Location header expected")
+                .expect("Expected Location header not provided.")
                 .to_str()
                 .unwrap(),
             "/new-path".to_string()

--- a/chico_server/src/handlers/redirect.rs
+++ b/chico_server/src/handlers/redirect.rs
@@ -1,0 +1,95 @@
+use chico_file::types;
+use http::{Response, StatusCode};
+use http_body_util::Full;
+
+use super::RequestHandler;
+
+pub struct RedirectHandler {
+    pub handler: types::Handler,
+}
+
+impl RequestHandler for RedirectHandler {
+    fn handle(
+        &self,
+        _request: hyper::Request<impl hyper::body::Body>,
+    ) -> http::Response<http_body_util::Full<hyper::body::Bytes>> {
+        if let types::Handler::Redirect { path, status_code } = &self.handler {
+            // Based on chico file path is always some
+            let path = path.clone().expect("Path value expect.");
+            let status_code = status_code.unwrap_or(StatusCode::FOUND.as_u16());
+
+            Response::builder()
+                .status(status_code)
+                .header(http::header::LOCATION, path)
+                .body(Full::default())
+                .unwrap()
+        } else {
+            unimplemented!(
+                "Only redirect handler is supported. Given handler was {}",
+                self.handler.type_name()
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chico_file::types;
+    use http::{Request, StatusCode};
+
+    use crate::{handlers::RequestHandler, test_utils::MockBody};
+
+    use super::RedirectHandler;
+
+    #[test]
+    fn test_redirect_handler_not_specified_status() {
+        let redirect_handler = RedirectHandler {
+            handler: types::Handler::Redirect {
+                path: Some("/new-path".to_string()),
+                status_code: None,
+            },
+        };
+
+        let request_body: MockBody = MockBody::new(b"");
+        let request = Request::builder().body(request_body).unwrap();
+
+        let response = redirect_handler.handle(request);
+
+        assert_eq!(&response.status(), &StatusCode::FOUND);
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::LOCATION)
+                .expect("Location header expected")
+                .to_str()
+                .unwrap(),
+            "/new-path".to_string()
+        );
+    }
+
+    #[test]
+    fn test_redirect_handler_specified_status() {
+        let redirect_handler = RedirectHandler {
+            handler: types::Handler::Redirect {
+                path: Some("/new-path".to_string()),
+                status_code: Some(307),
+            },
+        };
+
+        let request_body: MockBody = MockBody::new(b"");
+        let request = Request::builder().body(request_body).unwrap();
+
+        let response = redirect_handler.handle(request);
+
+        assert_eq!(&response.status(), &StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::LOCATION)
+                .expect("Location header expected")
+                .to_str()
+                .unwrap(),
+            "/new-path".to_string()
+        );
+    }
+}

--- a/chico_server/src/handlers/respond.rs
+++ b/chico_server/src/handlers/respond.rs
@@ -31,10 +31,9 @@ impl RequestHandler for RespondHandler {
 #[cfg(test)]
 mod tests {
 
-    use crate::handlers::RequestHandler;
+    use crate::{handlers::RequestHandler, test_utils::MockBody};
     use http::{Request, StatusCode};
     use http_body_util::BodyExt;
-    use hyper::body::{Body, Bytes};
 
     #[tokio::test]
     async fn test_respond_handler_specified_status_no_body() {
@@ -130,33 +129,5 @@ mod tests {
 
         assert_eq!(response_body, "Access denied");
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    }
-
-    struct MockBody {
-        data: &'static [u8],
-    }
-
-    impl MockBody {
-        fn new(data: &'static [u8]) -> Self {
-            Self { data }
-        }
-    }
-
-    impl Body for MockBody {
-        type Data = Bytes;
-        type Error = hyper::Error;
-
-        fn poll_frame(
-            mut self: std::pin::Pin<&mut Self>,
-            _cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
-            if self.data.is_empty() {
-                std::task::Poll::Ready(None)
-            } else {
-                let data = self.data;
-                self.data = &[];
-                std::task::Poll::Ready(Some(Ok(hyper::body::Frame::data(Bytes::from(data)))))
-            }
-        }
     }
 }

--- a/chico_server/src/main.rs
+++ b/chico_server/src/main.rs
@@ -7,7 +7,10 @@ mod cli;
 mod config;
 mod handlers;
 mod server;
+#[cfg(test)]
+mod test_utils;
 mod virtual_host;
+
 #[tokio::main]
 async fn main() {
     let cli = cli::CLI::parse();

--- a/chico_server/src/test_utils.rs
+++ b/chico_server/src/test_utils.rs
@@ -1,0 +1,29 @@
+use hyper::body::{Body, Bytes};
+
+pub struct MockBody {
+    data: &'static [u8],
+}
+
+impl MockBody {
+    pub fn new(data: &'static [u8]) -> Self {
+        Self { data }
+    }
+}
+
+impl Body for MockBody {
+    type Data = Bytes;
+    type Error = hyper::Error;
+
+    fn poll_frame(
+        mut self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        if self.data.is_empty() {
+            std::task::Poll::Ready(None)
+        } else {
+            let data = self.data;
+            self.data = &[];
+            std::task::Poll::Ready(Some(Ok(hyper::body::Frame::data(Bytes::from(data)))))
+        }
+    }
+}

--- a/chico_server/tests/server.rs
+++ b/chico_server/tests/server.rs
@@ -137,4 +137,44 @@ mod serial_integration {
         assert_eq!(&response.status(), &StatusCode::OK);
         assert_eq!(&response.text().await.unwrap(), "");
     }
+
+    #[tokio::test]
+    async fn test_redirect_handler_specified_status() {
+        let config_file_path =
+            Path::new("resources/test_cases/redirect-handler/specified_status.chf");
+        assert!(config_file_path.exists());
+
+        let mut app = ServerFixture::run_app(config_file_path);
+        app.wait_for_start();
+        let response = reqwest::get("http://localhost:3000/old-path")
+            .await
+            .unwrap();
+        app.stop_app();
+
+        assert_eq!(&response.status(), &StatusCode::OK);
+        assert_eq!(
+            &response.text().await.unwrap(),
+            "<h1>Redirected from old-path</h1>"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_redirect_handler_not_specified_status() {
+        let config_file_path =
+            Path::new("resources/test_cases/redirect-handler/not_specified_status.chf");
+        assert!(config_file_path.exists());
+
+        let mut app = ServerFixture::run_app(config_file_path);
+        app.wait_for_start();
+        let response = reqwest::get("http://localhost:3000/old-path")
+            .await
+            .unwrap();
+        app.stop_app();
+
+        assert_eq!(&response.status(), &StatusCode::OK);
+        assert_eq!(
+            &response.text().await.unwrap(),
+            "<h1>Redirected from old-path</h1>"
+        );
+    }
 }


### PR DESCRIPTION
This pull request introduces a new `RedirectHandler` to handle HTTP redirects in the `chico_server` project. The changes include adding the new handler, integrating it into the existing request handling system, and creating tests to ensure its functionality.

### New Features:
* **Redirect Handler Implementation**:
  * Added `RedirectHandler` struct and implemented `RequestHandler` for it to handle HTTP redirects. (`chico_server/src/handlers/redirect.rs`)
  * Integrated `RedirectHandler` into the `HandlerEnum` and updated the `select_handler` function to support redirects. (`chico_server/src/handlers.rs`) [[1]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L58-R61) [[2]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010R71-R79) [[3]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010R12-L12)
  * Added test cases for `RedirectHandler` to verify its behavior with specified and default status codes. (`chico_server/src/handlers/redirect.rs`)

### Codebase Enhancements:
* **Refactoring and Code Organization**:
  * Moved `MockBody` to a new `test_utils` module for reuse across different test files. (`chico_server/src/test_utils.rs`, `chico_server/src/main.rs`, `chico_server/src/handlers/respond.rs`) [[1]](diffhunk://#diff-7ae33c2c7a2ce10f6cba5238c86cc1837eb556f7e3aa55afe9e3c37d47b7b19cR1-R29) [[2]](diffhunk://#diff-9822dec37ad80b99d9e4c88d53e6fb487d551258389170275b0ad7c17f315f11R10-R13) [[3]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL34-L37) [[4]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL134-L161)

### Tests:
* **Integration Tests**:
  * Added integration tests for the `RedirectHandler` to ensure it works correctly within the application. (`chico_server/tests/server.rs`)

### Configuration:
* **Test Case Configuration**:
  * Added configuration files for testing redirects with and without specified status codes. (`chico_server/resources/test_cases/redirect-handler/not_specified_status.chf`, `chico_server/resources/test_cases/redirect-handler/specified_status.chf`) [[1]](diffhunk://#diff-3ee985c6b12d0a0503ea11e8359a2982ff0251cbf33c2b34b6fcda565f483966R1-R10) [[2]](diffhunk://#diff-033d641c28c2f2033d102e6ef90d57385c337c4902fcefb68f96f8171bb68d66R1-R10)