### PR TITLE
Handle 404

### DIFF
--- a/chico_server/src/handlers.rs
+++ b/chico_server/src/handlers.rs
@@ -15,6 +15,7 @@ pub trait RequestHandler {
     fn handle(&self, _request: hyper::Request<impl Body>) -> Response<Full<Bytes>>;
 }
 
+#[derive(PartialEq, Debug)]
 pub struct NullRequestHandler {}
 
 impl RequestHandler for NullRequestHandler {
@@ -64,6 +65,7 @@ pub fn select_handler(request: &hyper::Request<impl Body>, config: Config) -> Ha
     handler
 }
 
+#[derive(PartialEq, Debug)]
 pub enum HandlerEnum {
     #[allow(dead_code)]
     Null(NullRequestHandler),
@@ -91,8 +93,7 @@ impl HandlerEnum {
 <body>  
     <h1>404 Not Found</h1>  
 </body>  
-</html>  
-";
+</html>";
 
         HandlerEnum::Respond(RespondHandler {
             handler: chico_file::types::Handler::Respond {
@@ -100,5 +101,86 @@ impl HandlerEnum {
                 body: Some(body.to_string()),
             },
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chico_file::types::{Config, Handler, Route, VirtualHost};
+    use http::Request;
+
+    use crate::{handlers::HandlerEnum, test_utils::MockBody};
+
+    use super::{respond::RespondHandler, select_handler};
+
+    #[test]
+    fn test_select_handler_should_return_not_found_respond_handler_when_given_route_not_configured()
+    {
+        let config = Config {
+            virtual_hosts: vec![VirtualHost {
+                domain: "localhost".to_string(),
+                routes: vec![Route {
+                    handler: Handler::File("index.html".to_string()),
+                    path: "/".to_string(),
+                    middlewares: vec![],
+                }],
+            }],
+        };
+
+        let request = Request::builder()
+            .uri("http://localhost/blog")
+            .header(http::header::HOST, "localhost")
+            .body(MockBody::new(b""))
+            .unwrap();
+
+        let handler = select_handler(&request, config);
+
+        assert_eq!(HandlerEnum::not_found_respond_handler(), handler)
+    }
+
+    #[test]
+    fn test_select_handler_should_return_not_found_respond_handler_when_host_not_configured() {
+        let config = Config {
+            virtual_hosts: vec![VirtualHost {
+                domain: "localhost".to_string(),
+                routes: vec![Route {
+                    handler: Handler::File("index.html".to_string()),
+                    path: "/".to_string(),
+                    middlewares: vec![],
+                }],
+            }],
+        };
+
+        let request = Request::builder()
+            .uri("http://localhost:3000/blog")
+            .header(http::header::HOST, "localhost:3000")
+            .body(MockBody::new(b""))
+            .unwrap();
+
+        let handler = select_handler(&request, config);
+
+        assert_eq!(HandlerEnum::not_found_respond_handler(), handler)
+    }
+
+    #[test]
+    fn test_handler_enum_not_found_respond_handler() {
+        let body = r"<!DOCTYPE html>  
+<html>  
+<head>  
+    <title>404 Not Found</title>  
+</head>  
+<body>  
+    <h1>404 Not Found</h1>  
+</body>  
+</html>";
+
+        let handler = HandlerEnum::Respond(RespondHandler {
+            handler: chico_file::types::Handler::Respond {
+                status: Some(404),
+                body: Some(body.to_string()),
+            },
+        });
+
+        assert_eq!(handler, HandlerEnum::not_found_respond_handler())
     }
 }

--- a/chico_server/src/handlers.rs
+++ b/chico_server/src/handlers.rs
@@ -30,7 +30,7 @@ pub fn select_handler(request: &hyper::Request<impl Body>, config: Config) -> Ha
     let vh = &config.find_virtual_host(host.to_str().unwrap());
 
     if vh.is_none() {
-        todo!("abort connection in this case");
+        return HandlerEnum::not_found_respond_handler();
     }
 
     let vh = vh.unwrap();
@@ -38,7 +38,7 @@ pub fn select_handler(request: &hyper::Request<impl Body>, config: Config) -> Ha
     let route = vh.find_route(request.uri().path());
 
     if route.is_none() {
-        todo!("abort connection in this case");
+        return HandlerEnum::not_found_respond_handler();
     }
 
     let route = route.unwrap();
@@ -78,5 +78,27 @@ impl RequestHandler for HandlerEnum {
             HandlerEnum::Respond(handler) => handler.handle(request),
             HandlerEnum::Redirect(handler) => handler.handle(request),
         }
+    }
+}
+
+impl HandlerEnum {
+    pub fn not_found_respond_handler() -> HandlerEnum {
+        let body = r"<!DOCTYPE html>  
+<html>  
+<head>  
+    <title>404 Not Found</title>  
+</head>  
+<body>  
+    <h1>404 Not Found</h1>  
+</body>  
+</html>  
+";
+
+        HandlerEnum::Respond(RespondHandler {
+            handler: chico_file::types::Handler::Respond {
+                status: Some(404),
+                body: Some(body.to_string()),
+            },
+        })
     }
 }

--- a/chico_server/src/handlers/redirect.rs
+++ b/chico_server/src/handlers/redirect.rs
@@ -4,6 +4,7 @@ use http_body_util::Full;
 
 use super::RequestHandler;
 
+#[derive(PartialEq, Debug)]
 pub struct RedirectHandler {
     pub handler: types::Handler,
 }

--- a/chico_server/src/handlers/respond.rs
+++ b/chico_server/src/handlers/respond.rs
@@ -5,6 +5,7 @@ use hyper::body::{Body, Bytes};
 
 use super::RequestHandler;
 
+#[derive(PartialEq, Debug)]
 pub struct RespondHandler {
     pub handler: types::Handler,
 }

--- a/chico_server/tests/server.rs
+++ b/chico_server/tests/server.rs
@@ -177,4 +177,52 @@ mod serial_integration {
             "<h1>Redirected from old-path</h1>"
         );
     }
+
+    #[tokio::test]
+    async fn test_respond_handler_return_404_for_unknown_route() {
+        let config_file_path =
+            Path::new("resources/test_cases/respond-handler/simple_ok_response.chf");
+        assert!(config_file_path.exists());
+
+        let mut app = ServerFixture::run_app(config_file_path);
+        app.wait_for_start();
+        let response = reqwest::get("http://localhost:3000/blog").await.unwrap();
+        app.stop_app();
+
+        let body = r"<!DOCTYPE html>  
+<html>  
+<head>  
+    <title>404 Not Found</title>  
+</head>  
+<body>  
+    <h1>404 Not Found</h1>  
+</body>  
+</html>";
+
+        assert_eq!(&response.status(), &StatusCode::NOT_FOUND);
+        assert_eq!(&response.text().await.unwrap(), body);
+    }
+
+    #[tokio::test]
+    async fn test_respond_handler_return_404_for_unknown_host() {
+        let config_file_path =
+            Path::new("resources/test_cases/respond-handler/simple_ok_response.chf");
+        assert!(config_file_path.exists());
+
+        let mut app = ServerFixture::run_app(config_file_path);
+        app.wait_for_start();
+        let response = reqwest::get("http://127.0.0.1:3000").await.unwrap();
+        app.stop_app();
+        let body = r"<!DOCTYPE html>  
+<html>  
+<head>  
+    <title>404 Not Found</title>  
+</head>  
+<body>  
+    <h1>404 Not Found</h1>  
+</body>  
+</html>";
+        assert_eq!(&response.status(), &StatusCode::NOT_FOUND);
+        assert_eq!(&response.text().await.unwrap(), body);
+    }
 }


### PR DESCRIPTION
This pull request includes changes to the `chico_server/src/handlers.rs` file to handle 404 Not Found responses more gracefully. The most important changes include replacing `todo!` macros with a new `not_found_respond_handler` method and implementing this method in the `HandlerEnum` struct.

### Improvements to 404 Not Found handling:

* [`chico_server/src/handlers.rs`](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L33-R41): Replaced `todo!` macros with `HandlerEnum::not_found_respond_handler()` in the `select_handler` function to handle cases where the virtual host or route is not found.
* [`chico_server/src/handlers.rs`](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010R83-R104): Added the `not_found_respond_handler` method to the `HandlerEnum` implementation to return a 404 Not Found response with an HTML body.