### PR TITLE
Stop ServerFixture before unwrap response

### DIFF
--- a/chico_server/tests/server.rs
+++ b/chico_server/tests/server.rs
@@ -84,9 +84,10 @@ mod serial_integration {
 
         let mut app = ServerFixture::run_app(config_file_path);
         app.wait_for_start();
-        let response = reqwest::get("http://localhost:3000/").await.unwrap();
+        let response = reqwest::get("http://localhost:3000/").await;
         app.stop_app();
 
+        let response = response.unwrap();
         assert_eq!(&response.status(), &StatusCode::OK);
         assert_eq!(&response.text().await.unwrap(), "<h1>Example</h1>");
     }
@@ -99,11 +100,11 @@ mod serial_integration {
 
         let mut app = ServerFixture::run_app(config_file_path);
         app.wait_for_start();
-        let response = reqwest::get("http://localhost:3000/secret/data")
-            .await
-            .unwrap();
+        let response = reqwest::get("http://localhost:3000/secret/data").await;
+
         app.stop_app();
 
+        let response = response.unwrap();
         assert_eq!(&response.status(), &StatusCode::FORBIDDEN);
         assert_eq!(&response.text().await.unwrap(), "Access denied");
     }
@@ -116,9 +117,10 @@ mod serial_integration {
 
         let mut app = ServerFixture::run_app(config_file_path);
         app.wait_for_start();
-        let response = reqwest::get("http://localhost:3000/").await.unwrap();
+        let response = reqwest::get("http://localhost:3000/").await;
         app.stop_app();
 
+        let response = response.unwrap();
         assert_eq!(&response.status(), &StatusCode::OK);
         assert_eq!(&response.text().await.unwrap(), "<h1>Example</h1>");
     }
@@ -131,9 +133,10 @@ mod serial_integration {
 
         let mut app = ServerFixture::run_app(config_file_path);
         app.wait_for_start();
-        let response = reqwest::get("http://localhost:3000/health").await.unwrap();
+        let response = reqwest::get("http://localhost:3000/health").await;
         app.stop_app();
 
+        let response = response.unwrap();
         assert_eq!(&response.status(), &StatusCode::OK);
         assert_eq!(&response.text().await.unwrap(), "");
     }
@@ -146,11 +149,10 @@ mod serial_integration {
 
         let mut app = ServerFixture::run_app(config_file_path);
         app.wait_for_start();
-        let response = reqwest::get("http://localhost:3000/old-path")
-            .await
-            .unwrap();
+        let response = reqwest::get("http://localhost:3000/old-path").await;
         app.stop_app();
 
+        let response = response.unwrap();
         assert_eq!(&response.status(), &StatusCode::OK);
         assert_eq!(
             &response.text().await.unwrap(),
@@ -166,11 +168,10 @@ mod serial_integration {
 
         let mut app = ServerFixture::run_app(config_file_path);
         app.wait_for_start();
-        let response = reqwest::get("http://localhost:3000/old-path")
-            .await
-            .unwrap();
+        let response = reqwest::get("http://localhost:3000/old-path").await;
         app.stop_app();
 
+        let response = response.unwrap();
         assert_eq!(&response.status(), &StatusCode::OK);
         assert_eq!(
             &response.text().await.unwrap(),
@@ -186,7 +187,7 @@ mod serial_integration {
 
         let mut app = ServerFixture::run_app(config_file_path);
         app.wait_for_start();
-        let response = reqwest::get("http://localhost:3000/blog").await.unwrap();
+        let response = reqwest::get("http://localhost:3000/blog").await;
         app.stop_app();
 
         let body = r"<!DOCTYPE html>  
@@ -199,6 +200,7 @@ mod serial_integration {
 </body>  
 </html>";
 
+        let response = response.unwrap();
         assert_eq!(&response.status(), &StatusCode::NOT_FOUND);
         assert_eq!(&response.text().await.unwrap(), body);
     }
@@ -211,7 +213,7 @@ mod serial_integration {
 
         let mut app = ServerFixture::run_app(config_file_path);
         app.wait_for_start();
-        let response = reqwest::get("http://127.0.0.1:3000").await.unwrap();
+        let response = reqwest::get("http://127.0.0.1:3000").await;
         app.stop_app();
         let body = r"<!DOCTYPE html>  
 <html>  
@@ -222,6 +224,8 @@ mod serial_integration {
     <h1>404 Not Found</h1>  
 </body>  
 </html>";
+
+        let response = response.unwrap();
         assert_eq!(&response.status(), &StatusCode::NOT_FOUND);
         assert_eq!(&response.text().await.unwrap(), body);
     }


### PR DESCRIPTION
This pull request includes changes to the `chico_server/tests/server.rs` file to improve the handling of `reqwest` responses in the `serial_integration` module. The changes focus on separating the `unwrap` call from the `await` call to improve readability and error handling.

PR overview:
Moving the `unwrap` part after stopping the server to prevent resource leak.

Improvements to response handling:

* Modified the `reqwest::get` calls to separate the `unwrap` call from the `await` call for better readability and error handling in various test functions. [[1]](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988L87-R90) [[2]](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988L102-R107) [[3]](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988L119-R123) [[4]](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988L134-R139) [[5]](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988L149-R155) [[6]](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988L169-R174) [[7]](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988L189-R190) [[8]](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988R203) [[9]](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988L214-R216) [[10]](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988R227-R228)