### PR TITLE
Add content-type header to file-handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "mimee",
  "predicates",
  "reqwest",
  "rstest",
@@ -854,6 +855,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mimee"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4149ea534dbbbbc0ecccd1c0ac8b4c391b6256e9b187f51372a590e57876bd5f"
 
 [[package]]
 name = "minimal-lexical"

--- a/chico_server/Cargo.toml
+++ b/chico_server/Cargo.toml
@@ -16,6 +16,7 @@ http = "1.0"
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full"] }
 tokio-util = "0.7.13"
+mimee = { version = "0.1"}
 
 [dev-dependencies]
 rstest = "0.25.0"

--- a/chico_server/src/handlers/file.rs
+++ b/chico_server/src/handlers/file.rs
@@ -14,6 +14,9 @@ use crate::handlers::respond::RespondHandler;
 
 use super::RequestHandler;
 
+static MIME_DICT: std::sync::LazyLock<mimee::MimeDict> =
+    std::sync::LazyLock::new(|| mimee::MimeDict::new());
+
 #[derive(PartialEq, Debug)]
 pub struct FileHandler {
     pub handler: types::Handler,
@@ -51,10 +54,14 @@ impl RequestHandler for FileHandler {
                 return handle_file_error(_request, err_kind);
             }
 
-            Response::builder()
-                .status(StatusCode::OK)
-                .body(Full::new(Bytes::from_iter(buf)))
-                .unwrap()
+            let mut builder = Response::builder().status(StatusCode::OK);
+
+            let content_type = MIME_DICT.get_content_type(file_path.to_string());
+            if content_type.is_some() {
+                builder = builder.header(http::header::CONTENT_TYPE, content_type.unwrap());
+            }
+
+            builder.body(Full::new(Bytes::from_iter(buf))).unwrap()
         } else {
             unimplemented!(
                 "Only file handler is supported. Given handler was {}",

--- a/chico_server/src/handlers/file.rs
+++ b/chico_server/src/handlers/file.rs
@@ -148,6 +148,16 @@ mod tests {
         let response = file_handler.handle(request);
 
         assert_eq!(&response.status(), &StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "text/html"
+        );
+
         let response_body = String::from_utf8(
             response
                 .body()
@@ -193,6 +203,16 @@ mod tests {
 
         let response = file_handler.handle(request);
 
+        assert_eq!(&response.status(), &StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "text/html"
+        );
         assert_eq!(&response.status(), &StatusCode::OK);
         let response_body = String::from_utf8(
             response

--- a/chico_server/tests/server.rs
+++ b/chico_server/tests/server.rs
@@ -304,6 +304,16 @@ mod serial_integration {
 
         let response = response.unwrap();
         assert_eq!(&response.status(), &StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "text/html"
+        );
+        assert_eq!(&response.status(), &StatusCode::OK);
         assert_eq!(&response.text().await.unwrap(), content);
     }
 


### PR DESCRIPTION
This pull request introduces a new dependency on `mimee` to handle MIME types and updates the `FileHandler` to include content type headers in responses. Additionally, tests have been added and updated to verify the content type headers.

Dependency updates:

* Added `mimee` dependency in `Cargo.toml` to manage MIME types.

Handler updates:

* Introduced a static `MIME_DICT` to store MIME type mappings in `chico_server/src/handlers/file.rs`.
* Modified `FileHandler` to include `Content-Type` headers in responses based on file path.

Testing updates:

* Added assertions to verify `Content-Type` headers in `FileHandler` tests. [[1]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R151-R160) [[2]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R206-R215)
* Updated integration test in `chico_server/tests/server.rs` to check for `Content-Type` headers.