### PR TITLE
Make `handle` function in `RequestHandler` trait async

### DIFF
--- a/chico_server/src/handlers.rs
+++ b/chico_server/src/handlers.rs
@@ -14,14 +14,14 @@ mod file;
 mod redirect;
 mod respond;
 pub trait RequestHandler {
-    fn handle(&self, _request: hyper::Request<impl Body>) -> Response<Full<Bytes>>;
+    async fn handle(&self, _request: hyper::Request<impl Body>) -> Response<Full<Bytes>>;
 }
 
 #[derive(PartialEq, Debug)]
 pub struct NullRequestHandler {}
 
 impl RequestHandler for NullRequestHandler {
-    fn handle(&self, _request: hyper::Request<impl Body>) -> Response<Full<Bytes>> {
+    async fn handle(&self, _request: hyper::Request<impl Body>) -> Response<Full<Bytes>> {
         todo!()
     }
 }
@@ -79,12 +79,12 @@ pub enum HandlerEnum {
 }
 
 impl RequestHandler for HandlerEnum {
-    fn handle(&self, request: hyper::Request<impl Body>) -> Response<Full<Bytes>> {
+    async fn handle(&self, request: hyper::Request<impl Body>) -> Response<Full<Bytes>> {
         match self {
-            HandlerEnum::Null(handler) => handler.handle(request),
-            HandlerEnum::Respond(handler) => handler.handle(request),
-            HandlerEnum::Redirect(handler) => handler.handle(request),
-            HandlerEnum::File(handler) => handler.handle(request),
+            HandlerEnum::Null(handler) => handler.handle(request).await,
+            HandlerEnum::Respond(handler) => handler.handle(request).await,
+            HandlerEnum::Redirect(handler) => handler.handle(request).await,
+            HandlerEnum::File(handler) => handler.handle(request).await,
         }
     }
 }

--- a/chico_server/src/handlers/file.rs
+++ b/chico_server/src/handlers/file.rs
@@ -23,7 +23,7 @@ pub struct FileHandler {
 }
 
 impl RequestHandler for FileHandler {
-    fn handle(
+    async fn handle(
         &self,
         _request: hyper::Request<impl hyper::body::Body>,
     ) -> http::Response<http_body_util::Full<hyper::body::Bytes>> {
@@ -40,7 +40,7 @@ impl RequestHandler for FileHandler {
 
             if file.is_err() {
                 let err_kind = file.as_ref().err().unwrap().kind();
-                return handle_file_error(_request, err_kind);
+                return handle_file_error(_request, err_kind).await;
             }
 
             let mut file: File = file.unwrap();
@@ -51,7 +51,7 @@ impl RequestHandler for FileHandler {
             if read_result.is_err() {
                 let err_kind = read_result.as_ref().err().unwrap().kind();
 
-                return handle_file_error(_request, err_kind);
+                return handle_file_error(_request, err_kind).await;
             }
 
             let mut builder = Response::builder().status(StatusCode::OK);
@@ -71,7 +71,7 @@ impl RequestHandler for FileHandler {
     }
 }
 
-fn handle_file_error(
+async fn handle_file_error(
     _request: http::Request<impl hyper::body::Body>,
     error: ErrorKind,
 ) -> Response<Full<Bytes>> {
@@ -101,7 +101,7 @@ fn handle_file_error(
             },
         },
     };
-    return handler.handle(_request);
+    return handler.handle(_request).await;
 }
 
 #[cfg(test)]
@@ -145,7 +145,7 @@ mod tests {
         let request_body: MockBody = MockBody::new(b"");
         let request = Request::builder().body(request_body).unwrap();
 
-        let response = file_handler.handle(request);
+        let response = file_handler.handle(request).await;
 
         assert_eq!(&response.status(), &StatusCode::OK);
         assert_eq!(
@@ -201,7 +201,7 @@ mod tests {
         let request_body: MockBody = MockBody::new(b"");
         let request = Request::builder().body(request_body).unwrap();
 
-        let response = file_handler.handle(request);
+        let response = file_handler.handle(request).await;
 
         assert_eq!(&response.status(), &StatusCode::OK);
         assert_eq!(
@@ -240,7 +240,7 @@ mod tests {
         let request_body: MockBody = MockBody::new(b"");
         let request = Request::builder().body(request_body).unwrap();
 
-        let response = file_handler.handle(request);
+        let response = file_handler.handle(request).await;
 
         assert_eq!(&response.status(), &StatusCode::NOT_FOUND);
         let response_body = String::from_utf8(
@@ -270,7 +270,7 @@ mod tests {
         let request_body: MockBody = MockBody::new(b"");
         let request = Request::builder().body(request_body).unwrap();
 
-        let response = file_handler.handle(request);
+        let response = file_handler.handle(request).await;
 
         assert_eq!(&response.status(), &StatusCode::FORBIDDEN);
         let response_body = String::from_utf8(

--- a/chico_server/src/handlers/redirect.rs
+++ b/chico_server/src/handlers/redirect.rs
@@ -10,7 +10,7 @@ pub struct RedirectHandler {
 }
 
 impl RequestHandler for RedirectHandler {
-    fn handle(
+    async fn handle(
         &self,
         _request: hyper::Request<impl hyper::body::Body>,
     ) -> http::Response<http_body_util::Full<hyper::body::Bytes>> {
@@ -42,8 +42,8 @@ mod tests {
 
     use super::RedirectHandler;
 
-    #[test]
-    fn test_redirect_handler_not_specified_status() {
+    #[tokio::test]
+    async fn test_redirect_handler_not_specified_status() {
         let redirect_handler = RedirectHandler {
             handler: types::Handler::Redirect {
                 path: Some("/new-path".to_string()),
@@ -54,7 +54,7 @@ mod tests {
         let request_body: MockBody = MockBody::new(b"");
         let request = Request::builder().body(request_body).unwrap();
 
-        let response = redirect_handler.handle(request);
+        let response = redirect_handler.handle(request).await;
 
         assert_eq!(&response.status(), &StatusCode::FOUND);
         assert_eq!(
@@ -68,8 +68,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_redirect_handler_specified_status() {
+    #[tokio::test]
+    async fn test_redirect_handler_specified_status() {
         let redirect_handler = RedirectHandler {
             handler: types::Handler::Redirect {
                 path: Some("/new-path".to_string()),
@@ -80,7 +80,7 @@ mod tests {
         let request_body: MockBody = MockBody::new(b"");
         let request = Request::builder().body(request_body).unwrap();
 
-        let response = redirect_handler.handle(request);
+        let response = redirect_handler.handle(request).await;
 
         assert_eq!(&response.status(), &StatusCode::TEMPORARY_REDIRECT);
         assert_eq!(

--- a/chico_server/src/handlers/respond.rs
+++ b/chico_server/src/handlers/respond.rs
@@ -11,7 +11,7 @@ pub struct RespondHandler {
 }
 
 impl RequestHandler for RespondHandler {
-    fn handle(&self, _request: hyper::Request<impl Body>) -> hyper::Response<Full<Bytes>> {
+    async fn handle(&self, _request: hyper::Request<impl Body>) -> hyper::Response<Full<Bytes>> {
         if let types::Handler::Respond { status, body } = &self.handler {
             let status = status.unwrap_or(status::StatusCode::OK.as_u16());
             let body = body.as_ref().unwrap_or(&String::new()).clone();
@@ -50,7 +50,7 @@ mod tests {
         let request_body: MockBody = MockBody::new(b"");
 
         let request = Request::builder().body(request_body).unwrap();
-        let response = respond_handler.handle(request);
+        let response = respond_handler.handle(request).await;
 
         let response_body = String::from_utf8(
             response
@@ -82,7 +82,7 @@ mod tests {
         let request_body: MockBody = MockBody::new(b"Hello, world!");
 
         let request = Request::builder().body(request_body).unwrap();
-        let response = respond_handler.handle(request);
+        let response = respond_handler.handle(request).await;
 
         let response_body = String::from_utf8(
             response
@@ -114,7 +114,7 @@ mod tests {
         let request_body: MockBody = MockBody::new(b"Access denied");
 
         let request = Request::builder().body(request_body).unwrap();
-        let response = respond_handler.handle(request);
+        let response = respond_handler.handle(request).await;
 
         let response_body = String::from_utf8(
             response

--- a/chico_server/src/server.rs
+++ b/chico_server/src/server.rs
@@ -61,6 +61,6 @@ async fn handle_request(
     request: Request<impl Body>,
     config: Config,
 ) -> Result<Response<Full<Bytes>>, Infallible> {
-    let res = select_handler(&request, config).handle(request);
+    let res = select_handler(&request, config).handle(request).await;
     Ok(res)
 }


### PR DESCRIPTION
Close #19

This pull request introduces asynchronous handling to the request handlers in the `chico_server` project. The changes involve updating the `handle` method signatures to be asynchronous across various handler implementations and their corresponding tests.

Key changes include:

### Asynchronous Method Updates:
* [`chico_server/src/handlers.rs`](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L17-R24): Updated `RequestHandler` trait and its implementations to use `async fn handle` instead of `fn handle`. [[1]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L17-R24) [[2]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L82-R87)
* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L26-R26): Changed `FileHandler`'s `handle` method and `handle_file_error` function to be asynchronous. [[1]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L26-R26) [[2]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L43-R43) [[3]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L54-R54) [[4]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L74-R74) [[5]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L104-R104)
* [`chico_server/src/handlers/redirect.rs`](diffhunk://#diff-cea546a2396a4f2be98968ed074944ba7d7b25f52e7d543b5a57a80ebe365e82L13-R13): Modified `RedirectHandler`'s `handle` method to be asynchronous.
* [`chico_server/src/handlers/respond.rs`](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL14-R14): Updated `RespondHandler`'s `handle` method to be asynchronous.
* [`chico_server/src/server.rs`](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517L64-R64): Made the `handle_request` function asynchronous.

### Test Updates:
* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L148-R148): Updated tests to use `await` with the asynchronous `handle` method. [[1]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L148-R148) [[2]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L204-R204) [[3]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L243-R243) [[4]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L273-R273)
* [`chico_server/src/handlers/redirect.rs`](diffhunk://#diff-cea546a2396a4f2be98968ed074944ba7d7b25f52e7d543b5a57a80ebe365e82L45-R46): Converted tests to use `tokio::test` and `await` with the asynchronous `handle` method. [[1]](diffhunk://#diff-cea546a2396a4f2be98968ed074944ba7d7b25f52e7d543b5a57a80ebe365e82L45-R46) [[2]](diffhunk://#diff-cea546a2396a4f2be98968ed074944ba7d7b25f52e7d543b5a57a80ebe365e82L57-R57) [[3]](diffhunk://#diff-cea546a2396a4f2be98968ed074944ba7d7b25f52e7d543b5a57a80ebe365e82L71-R72) [[4]](diffhunk://#diff-cea546a2396a4f2be98968ed074944ba7d7b25f52e7d543b5a57a80ebe365e82L83-R83)
* [`chico_server/src/handlers/respond.rs`](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL53-R53): Updated tests to use `await` with the asynchronous `handle` method. [[1]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL53-R53) [[2]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL85-R85) [[3]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL117-R117)