### PR TITLE
Async file handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,8 +182,10 @@ name = "chico_server"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "bytes",
  "chico_file",
  "clap",
+ "futures-util",
  "http",
  "http-body-util",
  "hyper",

--- a/chico_server/Cargo.toml
+++ b/chico_server/Cargo.toml
@@ -17,6 +17,8 @@ http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full"] }
 tokio-util = "0.7.13"
 mimee = { version = "0.1"}
+futures-util = { version = "0.3", default-features = false }
+bytes = "1"
 
 [dev-dependencies]
 rstest = "0.25.0"

--- a/chico_server/src/handlers/file.rs
+++ b/chico_server/src/handlers/file.rs
@@ -28,6 +28,9 @@ impl RequestHandler for FileHandler {
         if let types::Handler::File(file_path) = &self.handler {
             let mut path = PathBuf::from(file_path);
 
+            if path.is_dir() {
+                return handle_file_error(_request, ErrorKind::IsADirectory).await;
+            }
             if !path.is_absolute() {
                 let exe_path = env::current_exe().unwrap();
                 let cd = exe_path.parent().unwrap();

--- a/chico_server/src/handlers/file.rs
+++ b/chico_server/src/handlers/file.rs
@@ -36,7 +36,7 @@ impl RequestHandler for FileHandler {
 
             let path_exist = tokio::fs::try_exists(&path).await;
 
-            if path_exist.is_ok() {
+            if let Ok(true) = path_exist {
                 let metadata = tokio::fs::metadata(&path).await;
                 if metadata.is_err() {
                     let err_kind = metadata.as_ref().err().unwrap().kind();

--- a/chico_server/src/handlers/redirect.rs
+++ b/chico_server/src/handlers/redirect.rs
@@ -1,8 +1,7 @@
 use chico_file::types;
 use http::{Response, StatusCode};
-use http_body_util::Full;
 
-use super::RequestHandler;
+use super::{full, BoxBody, RequestHandler};
 
 #[derive(PartialEq, Debug)]
 pub struct RedirectHandler {
@@ -13,7 +12,7 @@ impl RequestHandler for RedirectHandler {
     async fn handle(
         &self,
         _request: hyper::Request<impl hyper::body::Body>,
-    ) -> http::Response<http_body_util::Full<hyper::body::Bytes>> {
+    ) -> http::Response<BoxBody> {
         if let types::Handler::Redirect { path, status_code } = &self.handler {
             // Based on chico file path is always some
             let path = path.clone().expect("Expected path value not provided.");
@@ -22,7 +21,7 @@ impl RequestHandler for RedirectHandler {
             Response::builder()
                 .status(status_code)
                 .header(http::header::LOCATION, path)
-                .body(Full::default())
+                .body(full(""))
                 .unwrap()
         } else {
             unimplemented!(

--- a/chico_server/src/server.rs
+++ b/chico_server/src/server.rs
@@ -1,16 +1,11 @@
 use chico_file::types::Config;
 use http::{Request, Response};
-use http_body_util::Full;
-use hyper::{
-    body::{Body, Bytes},
-    server::conn::http1,
-    service::service_fn,
-};
+use hyper::{body::Body, server::conn::http1, service::service_fn};
 use hyper_util::rt::TokioIo;
 use std::{convert::Infallible, net::SocketAddr};
 use tokio::net::TcpListener;
 
-use crate::handlers::{select_handler, RequestHandler};
+use crate::handlers::{select_handler, BoxBody, RequestHandler};
 
 pub async fn run_server(config: Config) {
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
@@ -60,7 +55,6 @@ pub async fn run_server(config: Config) {
 async fn handle_request(
     request: Request<impl Body>,
     config: Config,
-) -> Result<Response<Full<Bytes>>, Infallible> {
-    let res = select_handler(&request, config).handle(request).await;
-    Ok(res)
+) -> Result<Response<BoxBody>, Infallible> {
+    Ok(select_handler(&request, config).handle(request).await)
 }


### PR DESCRIPTION
This pull request includes significant updates to the `chico_server` project, focusing on refactoring how HTTP bodies are handled across various modules. The changes primarily involve replacing the `Full` type with a new `BoxBody` type to improve flexibility and standardize response handling.

### Refactoring HTTP body handling:

* [`chico_server/src/handlers.rs`](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L6-R17): Updated the `RequestHandler` trait and its implementations to use `BoxBody` instead of `Full`. This includes modifications to the `handle` method and the introduction of a new `full` function to create `BoxBody` instances. [[1]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L6-R17) [[2]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010R63-L84)
* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L1-R13): Refactored the `FileHandler` to use async file operations and `BoxBody` for responses, replacing synchronous file reads and `Full` responses. [[1]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L1-R13) [[2]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L29-R47) [[3]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L64-R63) [[4]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L77-R76)
* [`chico_server/src/handlers/redirect.rs`](diffhunk://#diff-cea546a2396a4f2be98968ed074944ba7d7b25f52e7d543b5a57a80ebe365e82L3-R4): Modified the `RedirectHandler` to use `BoxBody` and the new `full` function for empty responses. [[1]](diffhunk://#diff-cea546a2396a4f2be98968ed074944ba7d7b25f52e7d543b5a57a80ebe365e82L3-R4) [[2]](diffhunk://#diff-cea546a2396a4f2be98968ed074944ba7d7b25f52e7d543b5a57a80ebe365e82L16-R15) [[3]](diffhunk://#diff-cea546a2396a4f2be98968ed074944ba7d7b25f52e7d543b5a57a80ebe365e82L25-R24)
* [`chico_server/src/handlers/respond.rs`](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL3-R18): Updated the `RespondHandler` to use `BoxBody` and the new `full` function for responses. Adjusted tests to reflect these changes. [[1]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL3-R18) [[2]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL55-R55) [[3]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL67-R64) [[4]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fR83-R87) [[5]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL100) [[6]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fR115-R119) [[7]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL132)
* [`chico_server/src/server.rs`](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517L3-R8): Changed the server's request handling to use `BoxBody` for responses, ensuring consistency with the updated handler implementations. [[1]](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517L3-R8) [[2]](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517L63-R59)

These changes enhance the flexibility and maintainability of the code by standardizing the way HTTP bodies are managed across different request handlers.