### PR TITLE
Update mimee dependency to version 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,9 +860,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mimee"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4149ea534dbbbbc0ecccd1c0ac8b4c391b6256e9b187f51372a590e57876bd5f"
+checksum = "fcbf8797840244af488a3b541b758a40e1f623a643903116d390995bb0456b52"
 
 [[package]]
 name = "minimal-lexical"

--- a/chico_server/Cargo.toml
+++ b/chico_server/Cargo.toml
@@ -16,7 +16,7 @@ http = "1.0"
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full"] }
 tokio-util = "0.7.13"
-mimee = { version = "0.1"}
+mimee = { version = "0.2"}
 futures-util = { version = "0.3", default-features = false }
 bytes = "1"
 

--- a/chico_server/src/handlers/file.rs
+++ b/chico_server/src/handlers/file.rs
@@ -61,7 +61,7 @@ impl RequestHandler for FileHandler {
 
             let mut builder = Response::builder().status(StatusCode::OK);
 
-            let content_type = MIME_DICT.get_content_type(file_path.to_string());
+            let content_type = MIME_DICT.get_content_type(file_path);
             if content_type.is_some() {
                 builder = builder.header(http::header::CONTENT_TYPE, content_type.unwrap());
             }


### PR DESCRIPTION
This pull request includes changes to update dependencies and improve code efficiency in the `chico_server` project. The most important changes are as follows:

Dependency updates:
* Updated `mimee` dependency from version `0.1` to `0.2` in `chico_server/Cargo.toml`.

Code efficiency improvements:
* Simplified the call to `get_content_type` by removing the unnecessary conversion of `file_path` to a string in `chico_server/src/handlers/file.rs`.