### PR TITLE
Refactor RespondHandler to simplify response creation

### DIFF
--- a/chico_server/src/handlers/file.rs
+++ b/chico_server/src/handlers/file.rs
@@ -88,30 +88,10 @@ async fn handle_file_error(
     error: ErrorKind,
 ) -> Response<BoxBody> {
     let handler = match error {
-        ErrorKind::NotFound => RespondHandler {
-            handler: types::Handler::Respond {
-                status: Some(404),
-                body: None,
-            },
-        },
-        ErrorKind::PermissionDenied => RespondHandler {
-            handler: types::Handler::Respond {
-                status: Some(403),
-                body: None,
-            },
-        },
-        ErrorKind::IsADirectory => RespondHandler {
-            handler: types::Handler::Respond {
-                status: Some(403),
-                body: None,
-            },
-        },
-        _ => RespondHandler {
-            handler: types::Handler::Respond {
-                status: Some(500),
-                body: None,
-            },
-        },
+        ErrorKind::NotFound => RespondHandler::not_found(),
+        ErrorKind::PermissionDenied => RespondHandler::forbidden(),
+        ErrorKind::IsADirectory => RespondHandler::forbidden(),
+        _ => RespondHandler::internal_server_error(),
     };
     return handler.handle(_request).await;
 }

--- a/chico_server/src/handlers/respond.rs
+++ b/chico_server/src/handlers/respond.rs
@@ -6,7 +6,69 @@ use super::{full, BoxBody, RequestHandler};
 
 #[derive(PartialEq, Debug)]
 pub struct RespondHandler {
-    pub handler: types::Handler,
+    handler: types::Handler,
+}
+
+impl RespondHandler {
+    #[allow(dead_code)]
+    pub fn new(status: u16, body: Option<String>) -> RespondHandler {
+        RespondHandler {
+            handler: types::Handler::Respond {
+                status: Some(status),
+                body: (body),
+            },
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn ok() -> RespondHandler {
+        RespondHandler::new(200, None)
+    }
+
+    #[allow(dead_code)]
+    pub fn ok_with_body(body: String) -> RespondHandler {
+        RespondHandler::new(200, Some(body))
+    }
+
+    #[allow(dead_code)]
+    pub fn bad_request() -> RespondHandler {
+        RespondHandler::new(400, None)
+    }
+
+    #[allow(dead_code)]
+    pub fn bad_request_with_body(body: String) -> RespondHandler {
+        RespondHandler::new(400, Some(body))
+    }
+
+    #[allow(dead_code)]
+    pub fn not_found() -> RespondHandler {
+        RespondHandler::new(404, None)
+    }
+
+    #[allow(dead_code)]
+    pub fn not_found_with_body(body: String) -> RespondHandler {
+        RespondHandler::new(404, Some(body))
+    }
+
+    #[allow(dead_code)]
+    pub fn forbidden() -> RespondHandler {
+        RespondHandler::new(403, None)
+    }
+
+    #[allow(dead_code)]
+    pub fn forbidden_with_body(body: String) -> RespondHandler {
+        RespondHandler::new(403, Some(body))
+    }
+
+    #[allow(dead_code)]
+    pub fn internal_server_error() -> RespondHandler {
+        RespondHandler::new(500, None)
+    }
+
+    #[allow(dead_code)]
+    pub fn internal_server_error_with_body(body: String) -> RespondHandler {
+        RespondHandler::new(500, Some(body))
+    }
 }
 
 impl RequestHandler for RespondHandler {


### PR DESCRIPTION
This pull request includes significant refactoring and improvements to the `RespondHandler` class and its usage across various parts of the codebase. The changes aim to simplify the code and improve maintainability by introducing new methods for creating common response handlers.

Improvements to `RespondHandler`:

* [`chico_server/src/handlers/respond.rs`](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fL9-R71): Added multiple new methods to the `RespondHandler` struct for creating response handlers with different statuses and optional bodies, such as `ok`, `bad_request`, `not_found`, `forbidden`, and `internal_server_error`.

Refactoring usage of `RespondHandler`:

* [`chico_server/src/handlers.rs`](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L46-R54): Updated the `select_handler` function to use the new `RespondHandler` methods for creating response handlers with specific statuses and bodies.
* [`chico_server/src/handlers.rs`](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L106-R109): Refactored the `impl HandlerEnum` block to use the new `RespondHandler` methods for creating response handlers with specific statuses and bodies.
* [`chico_server/src/handlers.rs`](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L195-R183): Updated test cases to use the new `RespondHandler` methods for creating response handlers with specific statuses and bodies. [[1]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L195-R183) [[2]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L209-R193)
* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L91-R94): Refactored the `handle_file_error` function to use the new `RespondHandler` methods for handling different error kinds.…or handling