### PR TITLE
Add test for handle_file_error

### DIFF
--- a/chico_server/src/test_utils.rs
+++ b/chico_server/src/test_utils.rs
@@ -1,5 +1,6 @@
 use hyper::body::{Body, Bytes};
 
+#[derive(Clone, Copy)]
 pub struct MockBody {
     data: &'static [u8],
 }


### PR DESCRIPTION
Close #23 

This pull request includes several changes to the `chico_server` module, specifically focusing on improving error handling and testing. The most important changes include updating imports, adding a new test function for error handling, and modifying the `MockBody` struct.

### Improvements to error handling and testing:

* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L101-R112): Updated imports to include `ErrorKind`, `RespondHandler`, and `rstest` to support new error handling functionality and testing.
* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R281-R304): Added a new test function `test_handle_file_error` to verify that different error kinds are handled correctly by the `handle_file_error` function. This test uses the `rstest` crate for parameterized testing.

### Codebase simplification:

* [`chico_server/src/test_utils.rs`](diffhunk://#diff-7ae33c2c7a2ce10f6cba5238c86cc1837eb556f7e3aa55afe9e3c37d47b7b19cR3): Added `Clone` and `Copy` traits to the `MockBody` struct to facilitate easier testing and manipulation of mock data.