### PR TITLE
Add tests for Respond Handler

### DIFF
--- a/chico_server/src/handlers/respond.rs
+++ b/chico_server/src/handlers/respond.rs
@@ -91,8 +91,12 @@ impl RequestHandler for RespondHandler {
 mod tests {
 
     use crate::{handlers::RequestHandler, test_utils::MockBody};
+    use chico_file::types;
     use http::{Request, StatusCode};
     use http_body_util::BodyExt;
+    use rstest::rstest;
+
+    use super::RespondHandler;
 
     #[tokio::test]
     async fn test_respond_handler_specified_status_no_body() {
@@ -188,5 +192,97 @@ mod tests {
         .unwrap();
 
         assert_eq!(response_body, "Access denied");
+    }
+
+    #[rstest]
+    #[case(200, None,RespondHandler {
+        handler: types::Handler::Respond {
+            status: Some(200),
+            body: None,
+        },
+    })]
+    #[case(200, Some("OK".to_string()),RespondHandler {
+        handler: types::Handler::Respond {
+            status: Some(200),
+            body: Some("OK".to_string()),
+        },
+    })]
+    fn test_respond_handler_new(
+        #[case] status: u16,
+        #[case] body: Option<String>,
+        #[case] result: RespondHandler,
+    ) {
+        let handler = RespondHandler::new(status, body);
+        assert_eq!(result, handler);
+    }
+
+    #[test]
+    fn test_respond_handler_ok() {
+        let handler = RespondHandler::ok();
+        assert_eq!(RespondHandler::new(200, None), handler);
+    }
+    #[test]
+    fn test_respond_handler_ok_with_body() {
+        let handler = RespondHandler::ok_with_body("Ok".to_string());
+        assert_eq!(RespondHandler::new(200, Some("Ok".to_string())), handler);
+    }
+
+    #[test]
+    fn test_respond_handler_bad_request() {
+        let handler = RespondHandler::bad_request();
+        assert_eq!(RespondHandler::new(400, None), handler);
+    }
+    #[test]
+    fn test_respond_handler_bad_request_with_body() {
+        let handler = RespondHandler::bad_request_with_body("Bad Request".to_string());
+        assert_eq!(
+            RespondHandler::new(400, Some("Bad Request".to_string())),
+            handler
+        );
+    }
+
+    #[test]
+    fn test_respond_handler_forbidden() {
+        let handler = RespondHandler::forbidden();
+        assert_eq!(RespondHandler::new(403, None), handler);
+    }
+    #[test]
+    fn test_respond_handler_forbidden_with_body() {
+        let handler = RespondHandler::forbidden_with_body("Forbidden".to_string());
+        assert_eq!(
+            RespondHandler::new(403, Some("Forbidden".to_string())),
+            handler
+        );
+    }
+
+    #[test]
+    fn test_respond_handler_not_found() {
+        let handler = RespondHandler::not_found();
+        assert_eq!(RespondHandler::new(404, None), handler);
+    }
+
+    #[test]
+    fn test_respond_handler_not_found_with_body() {
+        let handler = RespondHandler::not_found_with_body("Not Found".to_string());
+        assert_eq!(
+            RespondHandler::new(404, Some("Not Found".to_string())),
+            handler
+        );
+    }
+
+    #[test]
+    fn test_respond_handler_internal_server_error() {
+        let handler = RespondHandler::internal_server_error();
+        assert_eq!(RespondHandler::new(500, None), handler);
+    }
+
+    #[test]
+    fn test_respond_handler_internal_server_error_with_body() {
+        let handler =
+            RespondHandler::internal_server_error_with_body("Internal Server Error".to_string());
+        assert_eq!(
+            RespondHandler::new(500, Some("Internal Server Error".to_string())),
+            handler
+        );
     }
 }


### PR DESCRIPTION
This pull request adds new tests to the `RespondHandler` implementation in the `chico_server` project. These tests cover various scenarios to ensure the proper functionality of the `RespondHandler`.

Close #35 

### New Tests Added:

* Added `rstest` dependency and cases for `RespondHandler` to test different status and body combinations. [[1]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fR94-R99) [[2]](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fR196-R287)

* Created tests for `RespondHandler` factory methods:
  * `ok` and `ok_with_body` methods.
  * `bad_request` and `bad_request_with_body` methods.
  * `forbidden` and `forbidden_with_body` methods.
  * `not_found` and `not_found_with_body` methods.
  * `internal_server_error` and `internal_server_error_with_body` methods.