### PR TITLE
Refactor server to support multiple TCP listeners

### DIFF
--- a/chico_server/src/server.rs
+++ b/chico_server/src/server.rs
@@ -2,23 +2,50 @@ use chico_file::types::Config;
 use http::{Request, Response};
 use hyper::{body::Body, server::conn::http1, service::service_fn};
 use hyper_util::rt::TokioIo;
-use std::{convert::Infallible, net::SocketAddr};
+use std::{convert::Infallible, net::SocketAddr, sync::Arc};
 use tokio::net::TcpListener;
 
 use crate::handlers::{select_handler, BoxBody, RequestHandler};
 
 pub async fn run_server(config: Config) {
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    let ports = [3000];
 
-    let listener = match TcpListener::bind(addr).await {
-        Ok(listener) => listener,
-        Err(e) => {
-            eprintln!("Failed to bind to address {}: {:?}", addr, e);
-            return;
-        }
-    };
-    println!("Start listening requests on 3000");
+    let socket_addresses = ports.map(|port| SocketAddr::from(([127, 0, 0, 1], port)));
 
+    let mut listeners = vec![];
+
+    for addr in socket_addresses {
+        let listener = match TcpListener::bind(addr).await {
+            Ok(listener) => listener,
+            Err(e) => {
+                eprintln!("Failed to bind to address {}: {:?}", addr, e);
+                return;
+            }
+        };
+        listeners.push(listener);
+        println!(
+            "Start listening to incoming requests on port {}",
+            &addr.port()
+        );
+    }
+
+    let mut handles = vec![];
+
+    let config = Arc::new(config);
+
+    for listener in listeners {
+        let config_clone = config.clone();
+        let join_handle =
+            tokio::spawn(async move { handle_listener(config_clone, listener).await });
+        handles.push(join_handle);
+    }
+
+    for handle in handles {
+        let _ = handle.await; // Wait for each listener to complete
+    }
+}
+
+async fn handle_listener(config: Arc<Config>, listener: TcpListener) -> ! {
     loop {
         let (stream, _) = match listener.accept().await {
             Ok(conn) => conn,
@@ -27,29 +54,33 @@ pub async fn run_server(config: Config) {
                 continue;
             }
         };
-        // Use an adapter to access something implementing `tokio::io` traits as if they implement
-        // `hyper::rt` IO traits.
-        let io = TokioIo::new(stream);
-
-        // Spawn a tokio task to serve multiple connections concurrently
-        let config_clone = config.clone();
-
-        let service = service_fn(move |req| {
-            let config_clone = config_clone.clone();
-            async move { handle_request(req, config_clone).await }
-        });
-
-        tokio::task::spawn(async move {
-            // Finally, we bind the incoming connection to our `hello` service
-            if let Err(err) = http1::Builder::new()
-                // `service_fn` converts our function in a `Service`
-                .serve_connection(io, service)
-                .await
-            {
-                eprintln!("Error serving connection: {:?}", err);
-            }
-        });
+        handle_connection(&config, stream);
     }
+}
+
+fn handle_connection(config: &Config, stream: tokio::net::TcpStream) {
+    // Use an adapter to access something implementing `tokio::io` traits as if they implement
+    // `hyper::rt` IO traits.
+    let io = TokioIo::new(stream);
+
+    // Spawn a tokio task to serve multiple connections concurrently
+    let config_clone = config.clone();
+
+    let service = service_fn(move |req| {
+        let config_clone = config_clone.clone();
+        async move { handle_request(req, config_clone).await }
+    });
+
+    tokio::task::spawn(async move {
+        // Finally, we bind the incoming connection to our `hello` service
+        if let Err(err) = http1::Builder::new()
+            // `service_fn` converts our function in a `Service`
+            .serve_connection(io, service)
+            .await
+        {
+            eprintln!("Error serving connection: {:?}", err);
+        }
+    });
 }
 
 async fn handle_request(


### PR DESCRIPTION
This pull request includes changes to the `chico_server/src/server.rs` file to improve the server's ability to handle multiple ports and connections. The most important changes include the introduction of asynchronous handling for multiple ports, the use of `Arc` for shared configuration, and the addition of a new function to manage individual connections.

Improvements to server handling:

* [`chico_server/src/server.rs`](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517L5-R48): Added support for handling multiple ports by creating an array of socket addresses and binding listeners for each port.
* [`chico_server/src/server.rs`](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517L5-R48): Introduced `Arc` to share the configuration across multiple tasks safely.
* [`chico_server/src/server.rs`](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517L5-R48): Implemented a new asynchronous function `handle_listener` to manage each listener in its own task.
* [`chico_server/src/server.rs`](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517R57-R61): Added a new function `handle_connection` to handle individual connections, improving code modularity and readability.