### PR TITLE
Add env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,11 +185,13 @@ dependencies = [
  "bytes",
  "chico_file",
  "clap",
+ "env_logger",
  "futures-util",
  "http",
  "http-body-util",
  "hyper",
  "hyper-util",
+ "log",
  "mimee",
  "predicates",
  "reqwest",
@@ -292,6 +294,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -803,6 +828,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jiff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1086,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "predicates"

--- a/chico_file/src/lib.rs
+++ b/chico_file/src/lib.rs
@@ -1332,7 +1332,6 @@ mod tests {
                 }
             "#; // Missing closing brace
 
-            println!("{:?}", parse_config(input));
             assert!(parse_config(input).is_err());
         }
 

--- a/chico_file/src/lib.rs
+++ b/chico_file/src/lib.rs
@@ -119,10 +119,7 @@ fn parse_handler(input: &str) -> IResult<&str, types::Handler> {
         map(preceded(tag("browse"), parse_value), types::Handler::Browse),
         map(
             preceded(tag("respond"), parse_respond_handler_args),
-            |(status, body)| types::Handler::Respond {
-                status: status,
-                body: body,
-            },
+            |(status, body)| types::Handler::Respond { status, body },
         ),
         map(
             preceded(tag("redirect"), parse_redirect_handler_args),

--- a/chico_server/Cargo.toml
+++ b/chico_server/Cargo.toml
@@ -19,6 +19,8 @@ tokio-util = "0.7.13"
 mimee = { version = "0.2"}
 futures-util = { version = "0.3", default-features = false }
 bytes = "1"
+env_logger = "0.11.7"
+log = "0.4.26"
 
 [dev-dependencies]
 rstest = "0.25.0"

--- a/chico_server/src/main.rs
+++ b/chico_server/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
 use clap::Parser;
 use config::validate_config_file;
+use log::error;
 use server::run_server;
 use std::process::exit;
 mod cli;
@@ -13,13 +14,18 @@ mod virtual_host;
 
 #[tokio::main]
 async fn main() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .target(env_logger::Target::Stdout)
+        .init();
+
     let cli = cli::CLI::parse();
     match cli.command {
         cli::Commands::Run { config } => {
             let conf = validate_config_file(config.as_str())
                 .await
                 .unwrap_or_else(|err| {
-                    eprintln!("{}", err);
+                    error!("{}", err);
                     exit(1);
                 });
             run_server(conf).await

--- a/chico_server/src/server.rs
+++ b/chico_server/src/server.rs
@@ -2,6 +2,7 @@ use chico_file::types::Config;
 use http::{Request, Response};
 use hyper::{body::Body, server::conn::http1, service::service_fn};
 use hyper_util::rt::TokioIo;
+use log::{error, info};
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
 use tokio::net::TcpListener;
 
@@ -18,7 +19,7 @@ pub async fn run_server(config: Config) {
         let listener = match TcpListener::bind(addr).await {
             Ok(listener) => listener,
             Err(e) => {
-                eprintln!("Failed to bind to address {}: {:?}", addr, e);
+                error!("Failed to bind to address {}: {:?}", addr, e);
                 return;
             }
         };
@@ -26,7 +27,7 @@ pub async fn run_server(config: Config) {
 
         // We wait for following text to be written in standard output (stdout) in integration tests.
         // Any change at this message should be applied in tests.
-        println!(
+        info!(
             "Start listening to incoming requests on port {}",
             &addr.port()
         );
@@ -53,7 +54,7 @@ async fn handle_listener(config: Arc<Config>, listener: TcpListener) -> ! {
         let (stream, _) = match listener.accept().await {
             Ok(conn) => conn,
             Err(e) => {
-                eprintln!("Error accepting connection: {:?}", e);
+                error!("Error accepting connection: {:?}", e);
                 continue;
             }
         };
@@ -83,7 +84,7 @@ async fn handle_connection(config: Arc<Config>, stream: tokio::net::TcpStream) {
         .serve_connection(io, service)
         .await
     {
-        eprintln!("Error serving connection: {:?}", err);
+        error!("Error serving connection: {:?}", err);
     }
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve logging and error handling in the `chico_server` module, as well as a minor cleanup in the `chico_file` module. The most important changes include adding the `env_logger` and `log` dependencies, initializing the logger in the main function, and replacing `println!` and `eprintln!` statements with appropriate logging macros.

Improvements to logging:

* [`chico_server/Cargo.toml`](diffhunk://#diff-b74307ef38f2f493a527aaa8902e10f97c5ee198e8121ee1a5ecf6cf3ddee092R22-R23): Added `env_logger` and `log` dependencies to the project.
* [`chico_server/src/main.rs`](diffhunk://#diff-9822dec37ad80b99d9e4c88d53e6fb487d551258389170275b0ad7c17f315f11R4): Initialized the logger in the `main` function using `env_logger::builder()` and replaced `eprintln!` with `log::error!`. [[1]](diffhunk://#diff-9822dec37ad80b99d9e4c88d53e6fb487d551258389170275b0ad7c17f315f11R4) [[2]](diffhunk://#diff-9822dec37ad80b99d9e4c88d53e6fb487d551258389170275b0ad7c17f315f11R17-R28)
* [`chico_server/src/server.rs`](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517R5): Replaced `eprintln!` and `println!` statements with `log::error!` and `log::info!` respectively for better logging practices. [[1]](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517R5) [[2]](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517L21-R30) [[3]](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517L56-R57) [[4]](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517L86-R87)

Minor cleanup:

* [`chico_file/src/lib.rs`](diffhunk://#diff-0578f8acce4e211b930278d5011715a1be8ed428773497165682010a32b9d109L1335): Removed an unnecessary `println!` statement from the tests.