### PR TITLE
Implement get_ports method in ConfigExt trait and update server to use dynamic ports

### DIFF
--- a/chico_server/src/server.rs
+++ b/chico_server/src/server.rs
@@ -6,12 +6,17 @@ use log::{error, info};
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
 use tokio::net::TcpListener;
 
-use crate::handlers::{select_handler, BoxBody, RequestHandler};
+use crate::{
+    config::ConfigExt,
+    handlers::{select_handler, BoxBody, RequestHandler},
+};
 
 pub async fn run_server(config: Config) {
-    let ports = [3000];
+    let ports = config.get_ports();
 
-    let socket_addresses = ports.map(|port| SocketAddr::from(([127, 0, 0, 1], port)));
+    let socket_addresses = ports
+        .into_iter()
+        .map(|port| SocketAddr::from(([127, 0, 0, 1], port)));
 
     let mut listeners = vec![];
 


### PR DESCRIPTION
This pull request introduces several changes to the `chico_server` project, primarily focusing on enhancing configuration handling and adding new functionality for extracting ports from virtual hosts. The most important changes include the addition of a new method to retrieve ports, updates to the server to use this new method, and new tests to ensure the correctness of the changes.

Enhancements to configuration handling:

* [`chico_server/src/config.rs`](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acR1-R11): Added the `get_ports` method to the `ConfigExt` trait, which extracts ports from virtual hosts, defaulting to 80 for HTTP and 443 for HTTPS if not specified. [[1]](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acR1-R11) [[2]](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acR20-R37)

Updates to server functionality:

* [`chico_server/src/server.rs`](diffhunk://#diff-5a446baee85e9257f66b39a7c02556333e28254e09cd129c2dc01e4a6c604517L9-R19): Modified the server to use the `get_ports` method from `ConfigExt` to dynamically determine the ports to listen on, instead of using a hardcoded port array.

New tests for added functionality:

* [`chico_server/src/config.rs`](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acR340-R407): Added tests to verify the `get_ports` method works correctly when ports are specified and when they are not, ensuring default ports are used appropriately.

These changes improve the flexibility and robustness of the server configuration, ensuring it can handle a wider range of virtual host setups.