### PR TITLE
Enhance virtual host handling by adding port support

### DIFF
--- a/chico_server/resources/test_cases/respond-handler/ok_with_body_response.chf
+++ b/chico_server/resources/test_cases/respond-handler/ok_with_body_response.chf
@@ -4,9 +4,3 @@ localhost:3000 {
         respond "<h1>Example</h1>" 200
     }
 }
-
-localhost {
-    route / {
-        respond "<h1>Response from port 80</h1>" 200
-    }
-}

--- a/chico_server/resources/test_cases/respond-handler/ok_with_body_response.chf
+++ b/chico_server/resources/test_cases/respond-handler/ok_with_body_response.chf
@@ -4,3 +4,9 @@ localhost:3000 {
         respond "<h1>Example</h1>" 200
     }
 }
+
+localhost {
+    route / {
+        respond "<h1>Response from port 80</h1>" 200
+    }
+}

--- a/chico_server/src/handlers.rs
+++ b/chico_server/src/handlers.rs
@@ -2,10 +2,10 @@ use std::{str::FromStr, sync::Arc};
 
 use chico_file::types::Config;
 use file::FileHandler;
-use http::{uri::Scheme, Uri};
+use http::Uri;
 use redirect::RedirectHandler;
 
-use crate::{config::ConfigExt, virtual_host::VirtualHostExt};
+use crate::{config::ConfigExt, uri::UriExt, virtual_host::VirtualHostExt};
 use hyper::{
     body::{Body, Bytes},
     Response,
@@ -46,15 +46,7 @@ pub fn select_handler(request: &hyper::Request<impl Body>, config: Arc<Config>) 
     }
 
     let host = host.unwrap();
-    let port = uri.port_u16();
-    let scheme = uri.scheme();
-    let port = port.unwrap_or_else(|| {
-        if scheme == Some(&Scheme::HTTPS) {
-            443
-        } else {
-            80
-        }
-    });
+    let port = uri.get_port();
     let vh = &config.find_virtual_host(host, port);
 
     if vh.is_none() {

--- a/chico_server/src/main.rs
+++ b/chico_server/src/main.rs
@@ -10,8 +10,8 @@ mod handlers;
 mod server;
 #[cfg(test)]
 mod test_utils;
+mod uri;
 mod virtual_host;
-
 #[tokio::main]
 async fn main() {
     env_logger::builder()

--- a/chico_server/src/uri.rs
+++ b/chico_server/src/uri.rs
@@ -32,18 +32,16 @@ pub trait UriExt {
 
 impl UriExt for Uri {
     fn get_port(&self) -> u16 {
-        {
-            let uri = self;
-            let port = uri.port_u16();
-            let scheme = uri.scheme();
-            port.unwrap_or_else(|| {
-                if scheme == Some(&Scheme::HTTPS) {
-                    443
-                } else {
-                    80
-                }
-            })
-        }
+        let uri = self;
+        let port = uri.port_u16();
+        let scheme = uri.scheme();
+        port.unwrap_or_else(|| {
+            if scheme == Some(&Scheme::HTTPS) {
+                443
+            } else {
+                80
+            }
+        })
     }
 }
 

--- a/chico_server/src/uri.rs
+++ b/chico_server/src/uri.rs
@@ -1,6 +1,31 @@
 use http::{uri::Scheme, Uri};
 
+/// Extension trait for `Uri` to provide additional functionality.
 pub trait UriExt {
+    /// Retrieves the port number from the `Uri`.
+    ///
+    /// If the `Uri` does not explicitly specify a port, this method returns the default port
+    /// for the scheme: 443 for HTTPS and 80 for HTTP.
+    ///
+    /// # Returns
+    ///
+    /// * `u16` - The port number.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use chico_server::uri::UriExt;
+    /// use http::Uri;
+    ///
+    /// let uri: Uri = "https://example.com".parse().unwrap();
+    /// assert_eq!(uri.get_port(), 443);
+    ///
+    /// let uri: Uri = "http://example.com".parse().unwrap();
+    /// assert_eq!(uri.get_port(), 80);
+    ///
+    /// let uri: Uri = "http://example.com:8080".parse().unwrap();
+    /// assert_eq!(uri.get_port(), 8080);
+    /// ```
     #[allow(dead_code)]
     fn get_port(&self) -> u16;
 }

--- a/chico_server/src/uri.rs
+++ b/chico_server/src/uri.rs
@@ -1,0 +1,46 @@
+use http::{uri::Scheme, Uri};
+
+pub trait UriExt {
+    #[allow(dead_code)]
+    fn get_port(&self) -> u16;
+}
+
+impl UriExt for Uri {
+    fn get_port(&self) -> u16 {
+        {
+            let uri = self;
+            let port = uri.port_u16();
+            let scheme = uri.scheme();
+            port.unwrap_or_else(|| {
+                if scheme == Some(&Scheme::HTTPS) {
+                    443
+                } else {
+                    80
+                }
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use http::Uri;
+    use rstest::rstest;
+
+    use super::UriExt;
+
+    #[rstest]
+    #[case("localhost", 80)]
+    #[case("http://localhost", 80)]
+    #[case("http://localhost:3000", 3000)]
+    #[case("https://example.com", 443)]
+    #[case("https://example.com:3000", 3000)]
+    #[case("example.com:3000", 3000)]
+    #[case("example.com", 80)]
+    fn test_get_port(#[case] uri: &str, #[case] port: u16) {
+        let uri = Uri::from_str(uri).unwrap();
+        assert_eq!(uri.get_port(), port);
+    }
+}

--- a/chico_server/src/virtual_host.rs
+++ b/chico_server/src/virtual_host.rs
@@ -1,7 +1,11 @@
+use std::str::FromStr;
+
 use chico_file::types::{Route, VirtualHost};
+use http::{uri::Scheme, Uri};
 
 pub trait VirtualHostExt {
     fn find_route(&self, path: &str) -> Option<&Route>;
+    fn get_port(&self) -> u16;
 }
 
 impl VirtualHostExt for VirtualHost {
@@ -16,6 +20,18 @@ impl VirtualHostExt for VirtualHost {
             }
         });
         route
+    }
+    fn get_port(&self) -> u16 {
+        let uri = Uri::from_str(&self.domain).expect("Expected Valid host");
+        let port = uri.port_u16();
+        let scheme = uri.scheme();
+        port.unwrap_or_else(|| {
+            if scheme == Some(&Scheme::HTTPS) {
+                443
+            } else {
+                80
+            }
+        })
     }
 }
 

--- a/chico_server/src/virtual_host.rs
+++ b/chico_server/src/virtual_host.rs
@@ -1,7 +1,9 @@
 use std::str::FromStr;
 
 use chico_file::types::{Route, VirtualHost};
-use http::{uri::Scheme, Uri};
+use http::Uri;
+
+use crate::uri::UriExt;
 
 pub trait VirtualHostExt {
     fn find_route(&self, path: &str) -> Option<&Route>;
@@ -22,16 +24,9 @@ impl VirtualHostExt for VirtualHost {
         route
     }
     fn get_port(&self) -> u16 {
-        let uri = Uri::from_str(&self.domain).expect("Expected Valid host");
-        let port = uri.port_u16();
-        let scheme = uri.scheme();
-        port.unwrap_or_else(|| {
-            if scheme == Some(&Scheme::HTTPS) {
-                443
-            } else {
-                80
-            }
-        })
+        Uri::from_str(&self.domain)
+            .expect("Expected Valid host")
+            .get_port()
     }
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `chico_server` module to improve the handling of virtual hosts and URI parsing. The most important changes include updating the `ConfigExt` and `VirtualHostExt` traits, adding a new `UriExt` trait for URI extension methods, and enhancing error handling in the request handler.

Improvements to virtual host handling:

* [`chico_server/src/config.rs`](diffhunk://#diff-bc9dba9e894813cf557205c9595e78b51b6e6b0c0f47c7e0faa66cdeafe603acL7-R26): Modified the `find_virtual_host` method in the `ConfigExt` trait to include a port parameter and updated its implementation to use the new `UriExt` trait.
* [`chico_server/src/virtual_host.rs`](diffhunk://#diff-a669370440416a9ed9ef863366697194a17ed33d44e02447d14f54fe292f4e3fR1-R10): Added a `get_port` method to the `VirtualHostExt` trait and implemented it using the `UriExt` trait. [[1]](diffhunk://#diff-a669370440416a9ed9ef863366697194a17ed33d44e02447d14f54fe292f4e3fR1-R10) [[2]](diffhunk://#diff-a669370440416a9ed9ef863366697194a17ed33d44e02447d14f54fe292f4e3fR26-R30)

Enhancements to URI parsing:

* [`chico_server/src/uri.rs`](diffhunk://#diff-1f1f2cd53982fd91934e466fcdd0b850934e7603f005d045152845fcac4f56feR1-R71): Introduced a new `UriExt` trait that provides a `get_port` method to retrieve the port number from a `Uri`, with default ports for HTTP and HTTPS schemes.

Error handling improvements:

* [`chico_server/src/handlers.rs`](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010R31-R50): Enhanced the `select_handler` function to include additional checks for valid host headers and added a new `bad_request_invalid_host_header_respond_handler` method to handle invalid host headers. [[1]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010R31-R50) [[2]](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010R131-R135)

Code organization:

* [`chico_server/src/main.rs`](diffhunk://#diff-9822dec37ad80b99d9e4c88d53e6fb487d551258389170275b0ad7c17f315f11R13-L14): Added a new `uri` module to the project.