### PR TITLE
Refactor FileHandler to simplify initialization

### DIFF
--- a/chico_server/src/handlers.rs
+++ b/chico_server/src/handlers.rs
@@ -64,9 +64,7 @@ pub fn select_handler(request: &hyper::Request<impl Body>, config: Arc<Config>) 
     let route = route.unwrap();
 
     let handler: HandlerEnum = match &route.handler {
-        chico_file::types::Handler::File(_) => HandlerEnum::File(FileHandler {
-            handler: route.handler.clone(),
-        }),
+        chico_file::types::Handler::File(path) => HandlerEnum::File(FileHandler::new(path.clone())),
         chico_file::types::Handler::Proxy(_) => todo!(),
         chico_file::types::Handler::Dir(_) => todo!(),
         chico_file::types::Handler::Browse(_) => todo!(),


### PR DESCRIPTION
This pull request includes several changes to the `FileHandler` in the `chico_server` project. The primary focus is on refactoring the `FileHandler` to simplify its construction and usage. The most important changes are listed below:

Refactoring `FileHandler`:

* [`chico_server/src/handlers.rs`](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L67-R67): Modified the `select_handler` function to use the new `FileHandler::new` method for creating `FileHandler` instances.
* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L20-R37): Introduced a new `FileHandler::new` method that initializes `FileHandler` with a `path` and `is_dir` attribute, replacing the previous `types::Handler` attribute.
* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L77-L82): Removed the unimplemented handler type check in the `handle` method of `FileHandler`.

Code cleanup:

* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L3): Removed the unused import of `chico_file::types`.
* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L137-R139): Updated tests to use the new `FileHandler::new` method for creating `FileHandler` instances. [[1]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L137-R139) [[2]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L192-R192) [[3]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L230-R227) [[4]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L259-R253)