### PR TITLE
Add support for dynamic file routing in FileHandler

### DIFF
--- a/chico_server/resources/test_cases/file-handler/file_exist_return_ok.chf
+++ b/chico_server/resources/test_cases/file-handler/file_exist_return_ok.chf
@@ -3,10 +3,6 @@ localhost:3000 {
         file index.html
     }
     
-    route /downloads/v1/* {
-        file srv/v1/
-    }
-
     route /downloads/* {
         file srv/downloads/
     }

--- a/chico_server/resources/test_cases/file-handler/file_exist_return_ok.chf
+++ b/chico_server/resources/test_cases/file-handler/file_exist_return_ok.chf
@@ -2,4 +2,12 @@ localhost:3000 {
     route / {
         file index.html
     }
+    
+    route /downloads/v1/* {
+        file srv/v1/
+    }
+
+    route /downloads/* {
+        file srv/downloads/
+    }
 }

--- a/chico_server/src/handlers.rs
+++ b/chico_server/src/handlers.rs
@@ -64,7 +64,9 @@ pub fn select_handler(request: &hyper::Request<impl Body>, config: Arc<Config>) 
     let route = route.unwrap();
 
     let handler: HandlerEnum = match &route.handler {
-        chico_file::types::Handler::File(path) => HandlerEnum::File(FileHandler::new(path.clone())),
+        chico_file::types::Handler::File(path) => {
+            HandlerEnum::File(FileHandler::new(path.clone(), route.path.clone()))
+        }
         chico_file::types::Handler::Proxy(_) => todo!(),
         chico_file::types::Handler::Dir(_) => todo!(),
         chico_file::types::Handler::Browse(_) => todo!(),

--- a/chico_server/src/handlers/file.rs
+++ b/chico_server/src/handlers/file.rs
@@ -64,37 +64,39 @@ impl RequestHandler for FileHandler {
 
         if self.is_dir {
             let ending = extract_ending_from_req_path(&_request.uri().path(), &self.route);
-            path = path.join(ending);
+            if ending.is_none() {
+                return handle_file_error(_request, ErrorKind::NotFound).await;
+            }
+            path = path.join(ending.unwrap());
         };
 
-        let file = File::open(path).await;
+        let file = File::open(&path).await;
 
         if file.is_err() {
             let err_kind = file.as_ref().err().unwrap().kind();
             return handle_file_error(_request, err_kind).await;
         }
-        let file_path = &self.path;
         let file: File = file.unwrap();
-        process_file(file_path, file)
+        process_file(path.to_str().unwrap(), file)
     }
 }
 
-fn extract_ending_from_req_path(req_path: &str, route: &String) -> String {
-    let slash_index = route.rfind("/*").unwrap();
-    let route_without_asterisk = &route[..slash_index];
+fn extract_ending_from_req_path(req_path: &str, route: &String) -> Option<String> {
+    let slash_index = route.rfind("/*")?;
+    let route_without_asterisk = &route[..=slash_index];
     let route_without_asterisk_length = route_without_asterisk.len();
-    let i = req_path.rfind(route_without_asterisk).unwrap();
-    let ending = &req_path[i + route_without_asterisk_length + 1..];
-    ending.to_string()
+    let i = req_path.find(route_without_asterisk)?;
+    let ending = &req_path[i + route_without_asterisk_length..];
+    Some(ending.to_string())
 }
 
 fn process_file(
-    file_path: &String,
+    file_name: &str,
     file: File,
 ) -> Response<http_body_util::combinators::BoxBody<bytes::Bytes, std::io::Error>> {
     let mut builder = Response::builder().status(StatusCode::OK);
 
-    let content_type = MIME_DICT.get_content_type(file_path);
+    let content_type = MIME_DICT.get_content_type(file_name);
     if content_type.is_some() {
         builder = builder.header(http::header::CONTENT_TYPE, content_type.unwrap());
     }
@@ -177,6 +179,65 @@ mod tests {
                 .to_str()
                 .unwrap(),
             "text/html"
+        );
+
+        let response_body = String::from_utf8(
+            response
+                .boxed()
+                .collect()
+                .await
+                .unwrap()
+                .to_bytes()
+                .to_vec(),
+        )
+        .unwrap();
+        assert_eq!(response_body, content);
+
+        // Ignore the result of removing file
+        _ = std::fs::remove_file(file_path);
+    }
+
+    #[tokio::test]
+    async fn test_file_handler_return_ok_relative_path_and_dynamic_route() {
+        // For relative file we try to lookup file in directory or sub-directory of exe location
+        // Create file in executing directory
+        let exe_path = std::env::current_exe().unwrap();
+        let cd = exe_path.parent().unwrap();
+        let dir = cd.join("srv/dir1/dir2");
+        let file_path = &dir.join("hello.txt");
+
+        let content = r"Hello world!!!";
+        println!("{:?}", file_path);
+        std::fs::create_dir_all(dir).expect("Expected to create directories");
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+
+        // This is file handler for following config
+        // localhost {
+        //     route /* {
+        //         file srv/
+        //     }
+        // }
+
+        let file_handler = FileHandler::new("srv/".to_string(), "/*".to_string());
+
+        let request_body: MockBody = MockBody::new(b"");
+        let request = Request::builder()
+            .uri("http://localhost/dir1/dir2/hello.txt")
+            .body(request_body)
+            .unwrap();
+
+        let response = file_handler.handle(request).await;
+
+        assert_eq!(&response.status(), &StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "text/plain"
         );
 
         let response_body = String::from_utf8(
@@ -321,6 +382,7 @@ mod tests {
     }
 
     #[rstest]
+    #[case("/*", "/downloads/dir1/file.txt", "downloads/dir1/file.txt")]
     #[case("/downloads/*", "/downloads/dir1/file.txt", "dir1/file.txt")]
     #[case("/downloads/*", "/downloads/dir1/dir2/file.txt", "dir1/dir2/file.txt")]
     #[case(
@@ -340,6 +402,6 @@ mod tests {
         #[case] ending: &str,
     ) {
         let result = extract_ending_from_req_path(req_path, &route.to_string());
-        assert_eq!(ending.to_string(), result);
+        assert_eq!(ending.to_string(), result.unwrap());
     }
 }

--- a/chico_server/src/handlers/file.rs
+++ b/chico_server/src/handlers/file.rs
@@ -81,7 +81,7 @@ impl RequestHandler for FileHandler {
     }
 }
 
-fn extract_ending_from_req_path(req_path: &str, route: &String) -> Option<String> {
+fn extract_ending_from_req_path(req_path: &str, route: &str) -> Option<String> {
     let slash_index = route.rfind("/*")?;
     let route_without_asterisk = &route[..=slash_index];
     let route_without_asterisk_length = route_without_asterisk.len();
@@ -401,7 +401,7 @@ mod tests {
         #[case] req_path: &str,
         #[case] ending: &str,
     ) {
-        let result = extract_ending_from_req_path(req_path, &route.to_string());
+        let result = extract_ending_from_req_path(req_path, &route);
         assert_eq!(ending.to_string(), result.unwrap());
     }
 }

--- a/chico_server/tests/server.rs
+++ b/chico_server/tests/server.rs
@@ -326,7 +326,6 @@ mod serial_integration {
                 .unwrap(),
             "text/html"
         );
-        assert_eq!(&response.status(), &StatusCode::OK);
         assert_eq!(&response.text().await.unwrap(), content);
     }
 
@@ -366,7 +365,6 @@ mod serial_integration {
                 .unwrap(),
             "text/plain"
         );
-        assert_eq!(&response.status(), &StatusCode::OK);
         assert_eq!(&response.text().await.unwrap(), content);
     }
 


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of dynamic routes and file paths in the `chico_server` project. The most important changes include adding support for dynamic routes in the configuration, modifying the `FileHandler` to handle these routes, and adding corresponding tests to ensure the new functionality works correctly.

### Improvements to dynamic route handling:

* [`chico_server/resources/test_cases/file-handler/file_exist_return_ok.chf`](diffhunk://#diff-9234b42fb3f56812258e1e891a508d8fea4c061cd69a0057514a294e27db6961R5-R8): Added a new route to handle dynamic paths under `/downloads/*`.

* [`chico_server/src/handlers.rs`](diffhunk://#diff-7b25615abc942b791482d5a020d8bc0aeae89331ba68a36b47d9d3632a10c010L67-R69): Modified the `select_handler` function to pass the route path to the `FileHandler`.

### Enhancements to `FileHandler`:

* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R21-R29): Updated the `FileHandler` struct and its `new` method to include the route path, and adjusted the `handle` method to process dynamic routes correctly. [[1]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R21-R29) [[2]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L37-R39) [[3]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R57-R99) [[4]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L87)

### Testing improvements:

* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R143-R144): Added new tests for handling dynamic routes and verifying the correct file is returned. [[1]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R143-R144) [[2]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L139-R166) [[3]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R200-R258) [[4]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L192-R279) [[5]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L227-R314) [[6]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L253-R340) [[7]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R383-R406)

* [`chico_server/tests/server.rs`](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988R329-R367): Added an integration test to verify the server correctly handles dynamic routes.