### PR TITLE
Add support for Range requests in file handling

### DIFF
--- a/chico_server/resources/test_cases/file-handler/file_exist_return_ok.chf
+++ b/chico_server/resources/test_cases/file-handler/file_exist_return_ok.chf
@@ -2,6 +2,10 @@ localhost:3000 {
     route / {
         file index.html
     }
+
+    route /test.txt {
+        file test.txt
+    }
     
     route /downloads/* {
         file srv/downloads/

--- a/chico_server/src/handlers/file.rs
+++ b/chico_server/src/handlers/file.rs
@@ -153,8 +153,9 @@ async fn process_file(
         let (start, end) = range[0];
         let content_length = end - start + 1;
 
-        file.seek(SeekFrom::Start(start)).await.unwrap();
-
+        if let Err(e) = file.seek(SeekFrom::Start(start)).await {
+            return handle_file_error(request, e.kind()).await;
+        };
         let stream = ReaderStream::new(file.take(content_length));
         let stream_body = StreamBody::new(stream.map_ok(Frame::data));
         let boxed_body = stream_body.boxed();

--- a/chico_server/src/handlers/file.rs
+++ b/chico_server/src/handlers/file.rs
@@ -83,7 +83,14 @@ impl RequestHandler for FileHandler {
             let err_kind = file.as_ref().err().unwrap().kind();
             return handle_file_error(_request, err_kind).await;
         }
+
+        let metadata = tokio::fs::metadata(&path).await;
+        if metadata.is_err() {
+            let err_kind = metadata.as_ref().err().unwrap().kind();
+            return handle_file_error(_request, err_kind).await;
+        }
         let file: File = file.unwrap();
+        let metadata = &metadata.unwrap();
         process_file(_request, path.to_str().unwrap(), file, metadata).await
     }
 }

--- a/chico_server/src/handlers/file.rs
+++ b/chico_server/src/handlers/file.rs
@@ -308,7 +308,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_file_handler_head_request_set_content_length() {
+    async fn test_file_handler_head_request_set_required_headers() {
         let content = r"<!DOCTYPE html>  
         <html>  
         <head>  
@@ -360,6 +360,15 @@ mod tests {
                 .to_str()
                 .unwrap(),
             file_size.to_string()
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::ACCEPT_RANGES)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "bytes".to_string()
         );
 
         let response_body = String::from_utf8(

--- a/chico_server/src/handlers/respond.rs
+++ b/chico_server/src/handlers/respond.rs
@@ -69,6 +69,11 @@ impl RespondHandler {
     pub fn internal_server_error_with_body(body: String) -> RespondHandler {
         RespondHandler::new(500, Some(body))
     }
+
+    #[allow(dead_code)]
+    pub fn range_not_satisfiable() -> RespondHandler {
+        RespondHandler::new(416, None)
+    }
 }
 
 impl RequestHandler for RespondHandler {


### PR DESCRIPTION
This pull request introduces a series of changes to enhance the file handling capabilities of the `chico_server` project, particularly focusing on range requests, error handling, and testing. The most significant changes include adding support for HTTP range requests, improving error handling, and expanding the test coverage.

Enhancements to file handling:

* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L93-R180): Added support for HTTP range requests by implementing the `parse_range` function and modifying the `process_file` function to handle range headers. This includes returning appropriate responses for valid and invalid range requests. [[1]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L93-R180) [[2]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R195-R235)

Error handling improvements:

* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5L49-L63): Improved error handling in the `FileHandler` by using the `is_ok_and` method to check the existence of the file and returning specific errors for different conditions, such as `ErrorKind::NotFound` and `ErrorKind::IsADirectory`.
* [`chico_server/src/handlers/respond.rs`](diffhunk://#diff-1b6a46b497570178c1f7d01a03b7b2a8672b50fb5b48061bb4677ecc189a721fR72-R76): Added a new method `range_not_satisfiable` to the `RespondHandler` to handle 416 Range Not Satisfiable errors.

Test coverage expansion:

* [`chico_server/src/handlers/file.rs`](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R314-R390): Added multiple tests to cover the new range request functionality, including tests for valid and invalid ranges, as well as edge cases. [[1]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R314-R390) [[2]](diffhunk://#diff-e5a30202ba9014b38734462aea256bebbfd19e1d426ceb3028de12afa071e6e5R598-R729)
* [`chico_server/tests/server.rs`](diffhunk://#diff-85f40e26b2023a99ebcac6a9c742b71d2a6fdbfdbfd1cc08a632f45833c28988R388-R532): Added integration tests to verify the behavior of the file handler for HEAD requests and range requests, ensuring proper headers and responses are returned.

Configuration updates:

* [`chico_server/resources/test_cases/file-handler/file_exist_return_ok.chf`](diffhunk://#diff-9234b42fb3f56812258e1e891a508d8fea4c061cd69a0057514a294e27db6961R6-R9): Added a new route for `test.txt` to facilitate testing of the file handler with different file types.

These changes collectively improve the robustness and functionality of the file handling system in the `chico_server` project, ensuring better compliance with HTTP standards and more comprehensive test coverage.