### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/Alirexaa/chico/security/code-scanning/29](https://github.com/Alirexaa/chico/security/code-scanning/29)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily reads repository contents and does not perform write operations, the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job. In this case, adding it at the root level is more efficient and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
